### PR TITLE
reduce expired timeout to commit changes faster

### DIFF
--- a/lib/Channel/SessionManager.php
+++ b/lib/Channel/SessionManager.php
@@ -27,7 +27,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 class SessionManager {
-        const EXPIRED_SESSION_TIMEOUT = 15;
+        const EXPIRED_SESSION_TIMEOUT = 30;
 	private $connection;
 	private $timeFactory;
 	private $ipcFactory;

--- a/lib/Channel/SessionManager.php
+++ b/lib/Channel/SessionManager.php
@@ -27,6 +27,7 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 class SessionManager {
+        const EXPIRED_SESSION_TIMEOUT = 15;
 	private $connection;
 	private $timeFactory;
 	private $ipcFactory;
@@ -127,7 +128,8 @@ class SessionManager {
 	private function getExpiredSessions(): array {
 		$query = $this->connection->getQueryBuilder();
 
-		$cutoffTime = $this->timeFactory->getTime() - (Channel::TIMEOUT * 4);
+		$cutoffTime = $this->timeFactory->getTime() -
+		        EXPIRED_SESSION_TIMEOUT;
 
 		$query->select('session_id')
 			->from('documentserver_sess')


### PR DESCRIPTION
This reduces the timeout to mark a page inactive from 100 seconds to
15 seconds.  This allows for saved pages to be committed more quickly.

Addresses issues in nextcloud/documentserver_community#100

Signed-off-by: Joseph C Wang <joequant@gmail.com>