### PR TITLE
[Fix #222] fixing error message related to EXPIRED_SESSION_TIMEOUT

### DIFF
--- a/lib/Channel/SessionManager.php
+++ b/lib/Channel/SessionManager.php
@@ -131,7 +131,7 @@ class SessionManager {
 		$query = $this->connection->getQueryBuilder();
 
 		$cutoffTime = $this->timeFactory->getTime() -
-		        EXPIRED_SESSION_TIMEOUT;
+		        self::EXPIRED_SESSION_TIMEOUT;
 
 		$query->select('session_id')
 			->from('documentserver_sess')


### PR DESCRIPTION
This simple fix removes the following error message:
```
Error: Use of undefined constant EXPIRED_SESSION_TIMEOUT - assumed 'EXPIRED_SESSION_TIMEOUT' (this will throw an Error in a future version of PHP) at /var/www/html/custom_apps/documentserver_community/lib/Channel/SessionManager.php#134
```
as well as:
```
Error: A non-numeric value encountered at /var/www/html/custom_apps/documentserver_community/lib/Channel/SessionManager.php#134
```