### PR TITLE
Bumped OnlyOffice to version 6.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ clean:
 
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice
-	docker create --name oo-extract onlyoffice/documentserver:6.3.1.32
+	docker create --name oo-extract onlyoffice/documentserver:6.4.2.6
 	docker cp oo-extract:/var/www/onlyoffice/documentserver 3rdparty/onlyoffice
 	docker rm oo-extract
-	rm -r 3rdparty/onlyoffice/documentserver/server/{SpellChecker,Common,DocService}
+	rm -r 3rdparty/onlyoffice/documentserver/server/Common
+	rm -r 3rdparty/onlyoffice/documentserver/server/DocService
 	cd 3rdparty/onlyoffice/documentserver/server/FileConverter/bin && \
 		../../tools/allfontsgen \
 		--input="../../../core-fonts" \

--- a/lib/OnlyOffice/WebVersion.php
+++ b/lib/OnlyOffice/WebVersion.php
@@ -25,6 +25,6 @@ namespace OCA\DocumentServer\OnlyOffice;
 
 class WebVersion {
 	public function getWebUIVersion(): string {
-		return '6.3.1';
+		return '6.4.2';
 	}
 }


### PR DESCRIPTION
Exact version according to docker image: 6.4.2.6

Other changes:
Removed curly bracket notation since this might not be supported by bash in make (at least on my Ubuntu 21.04 with make 4.3)
Removed folder "SpellChecker" from remove command, since it does not exist in that OnlyOffice release anymore

This would also fix issue #233 .