### PR TITLE
Update info.xml

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,7 +31,7 @@ Additionally, the community document server only supports running on x86-64 Linu
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/main.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/new.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="21" max-version="23"/>
+		<nextcloud min-version="21" max-version="24"/>
 	</dependencies>
 
 	<background-jobs>


### PR DESCRIPTION
According to my tests, the app is fully compatible with NC 24.0.1. 
Closes issue [#260 ](https://github.com/nextcloud/documentserver_community/issues/260)