### PR TITLE
Update app to latest document server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 3rdparty/onlyoffice
 build
+oo-extract
+*.rpm

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ all: 3rdparty/onlyoffice/documentserver version
 clean:
 	rm -rf 3rdparty/onlyoffice
 	rm -rf build
-	docker rm -if oo-extract
 
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ clean:
 	docker create --name oo-extract onlyoffice/documentserver:7.2.1
 	docker cp oo-extract:/var/www/onlyoffice/documentserver 3rdparty/onlyoffice
 	docker rm oo-extract
+	chmod -R +w 3rdparty/
 	rm -rf 3rdparty/onlyoffice/documentserver/server/{Common,DocService}
 	cd 3rdparty/onlyoffice/documentserver/server/FileConverter/bin && \
 		../../tools/allfontsgen \

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,15 @@ clean:
 
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice
-	docker create --name oo-extract onlyoffice/documentserver:7.2.1
-	docker cp oo-extract:/var/www/onlyoffice/documentserver 3rdparty/onlyoffice
-	docker rm oo-extract
-	chmod -R 777 3rdparty/
-	cp 3rdparty/onlyoffice/documentserver/server/FileConverter/bin/lib*.so* 3rdparty/onlyoffice/documentserver/server/tools/
+	mkdir -p oo-extract
+	curl -sLO https://github.com/ONLYOFFICE/DocumentServer/releases/download/v7.2.1/onlyoffice-documentserver.x86_64.rpm
+	cd oo-extract && rpm2cpio ../onlyoffice-documentserver.x86_64.rpm | cpio -idm
+	chmod -R 777 oo-extract/
+	cp -r oo-extract/var/www/onlyoffice/documentserver 3rdparty/onlyoffice
+	cp oo-extract/usr/lib64/* 3rdparty/onlyoffice/documentserver/server/FileConverter/bin/
+	cp oo-extract/usr/lib64/* 3rdparty/onlyoffice/documentserver/server/tools/
+	rm -rf oo-extract
+	rm -f onlyoffice-documentserver.x86_64.rpm
 	rm -rf 3rdparty/onlyoffice/documentserver/server/{Common,DocService}
 	cd 3rdparty/onlyoffice/documentserver/server/tools && \
 		./allfontsgen \

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ clean:
 
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice
-	docker create --name oo-extract onlyoffice/documentserver:6.4.2.6
+	docker create --name oo-extract onlyoffice/documentserver:7.2.1
 	docker cp oo-extract:/var/www/onlyoffice/documentserver 3rdparty/onlyoffice
 	docker rm oo-extract
-	rm -r 3rdparty/onlyoffice/documentserver/server/{Common,DocService}
+	rm -rf 3rdparty/onlyoffice/documentserver/server/{Common,DocService}
 	cd 3rdparty/onlyoffice/documentserver/server/FileConverter/bin && \
 		../../tools/allfontsgen \
 		--input="../../../core-fonts" \

--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,24 @@ all: 3rdparty/onlyoffice/documentserver version
 clean:
 	rm -rf 3rdparty/onlyoffice
 	rm -rf build
+	docker rm -if oo-extract
 
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice
 	docker create --name oo-extract onlyoffice/documentserver:7.2.1
 	docker cp oo-extract:/var/www/onlyoffice/documentserver 3rdparty/onlyoffice
 	docker rm oo-extract
-	chmod -R +w 3rdparty/
+	chmod -R 777 3rdparty/
+	cp 3rdparty/onlyoffice/documentserver/server/FileConverter/bin/lib*.so* 3rdparty/onlyoffice/documentserver/server/tools/
 	rm -rf 3rdparty/onlyoffice/documentserver/server/{Common,DocService}
-	cd 3rdparty/onlyoffice/documentserver/server/FileConverter/bin && \
-		../../tools/allfontsgen \
-		--input="../../../core-fonts" \
-		--allfonts-web="../../../sdkjs/common/AllFonts.js" \
-		--allfonts="AllFonts.js" \
-		--images="../../../sdkjs/common/Images" \
-		--output-web="../../../fonts" \
-		--selection="font_selection.bin"
+	cd 3rdparty/onlyoffice/documentserver/server/tools && \
+		./allfontsgen \
+		--input="../../core-fonts" \
+		--allfonts-web="../../sdkjs/common/AllFonts.js" \
+		--allfonts="../FileConverter/bin/AllFonts.js" \
+		--images="../../sdkjs/common/Images" \
+		--output-web="../../fonts" \
+		--selection="../FileConverter/bin/font_selection.bin"
 	sed -i 's/if(yb===d\[a\].ka)/if(d[a]\&\&yb===d[a].ka)/' 3rdparty/onlyoffice/documentserver/sdkjs/*/sdk-all.js
 
 version:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ We'd like to also support ARM devices like the Raspberry Pi in the future.
 The community documentserver will automatically configure itself if no other document server is configured in the onlyoffice settings ("Document Editing Service address" is empty).
 All other "Server settings" should be left empty.
 
+If autoconfiguration fails for any reason, you may manually enter the url. Log in as the dsmin and go to Settings > ONLYOFFICE. For the ONLYOFFICE Docs address, enter the value in the format of `https://<nextcloud_server>/apps/documentserver_community/`.
+
 ## Adding fonts
 
 You can add custom fonts to the document server using the following occ commands

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Specific commands and paths will differ based on your specific setup.
 
 ## Setup from git
 
-When installing from git `make` and `docker` are required.
+When installing from git `make`, `curl`, `rpm2cpio`, and `cpio` are required.
 
 - clone the repo into the Nextcloud app directory 
 - run `make` in the app folder to download the 3rdparty components

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We'd like to also support ARM devices like the Raspberry Pi in the future.
 The community documentserver will automatically configure itself if no other document server is configured in the onlyoffice settings ("Document Editing Service address" is empty).
 All other "Server settings" should be left empty.
 
-If autoconfiguration fails for any reason, you may manually enter the url. Log in as the dsmin and go to Settings > ONLYOFFICE. For the ONLYOFFICE Docs address, enter the value in the format of `https://<nextcloud_server>/apps/documentserver_community/`.
+If autoconfiguration fails for any reason, you may manually enter the url. Log in as the admin and go to Settings > ONLYOFFICE. For the ONLYOFFICE Docs address, enter the value in the format of `https://<nextcloud_server>/apps/documentserver_community/`.
 
 ## Adding fonts
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ The community document server will automatically be configured if no other docum
 
 Additionally, the community document server only supports running on x86-64 Linux servers.]]>
 	</description>
-	<version>0.1.12</version>
+	<version>0.1.13</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>DocumentServer</namespace>
@@ -31,7 +31,7 @@ Additionally, the community document server only supports running on x86-64 Linu
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/main.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/new.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="21" max-version="23"/>
+		<nextcloud min-version="21" max-version="25"/>
 	</dependencies>
 
 	<background-jobs>

--- a/lib/OnlyOffice/WebVersion.php
+++ b/lib/OnlyOffice/WebVersion.php
@@ -25,6 +25,6 @@ namespace OCA\DocumentServer\OnlyOffice;
 
 class WebVersion {
 	public function getWebUIVersion(): string {
-		return '6.4.2';
+		return '7.2.1';
 	}
 }


### PR DESCRIPTION
- Bumps document server to version 7.2.1
- Bumps supported Nextcloud to version 25
- Fixes segfaults in both local dev and most app environments
- Improves `make clean`
- Docker is now compiled differently from generic linux builds; this change pulls in document server by extracting from rpm instead of Docker

Signed-off-by: Aaron Huggins <aaron.huggins@runbox.com>