### PR TITLE
Nextcloud27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice
 	mkdir -p oo-extract
-	curl -sLO https://github.com/ONLYOFFICE/DocumentServer/releases/download/v7.4.1/onlyoffice-documentserver.x86_64.rpm
+	curl -sLO https://github.com/ONLYOFFICE/DocumentServer/releases/download/v7.2.2/onlyoffice-documentserver.x86_64.rpm
 	cd oo-extract && rpm2cpio ../onlyoffice-documentserver.x86_64.rpm | cpio -idm
 	chmod -R 777 oo-extract/
 	cp -r oo-extract/var/www/onlyoffice/documentserver 3rdparty/onlyoffice

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice
 	mkdir -p oo-extract
-	curl -sLO https://github.com/ONLYOFFICE/DocumentServer/releases/download/v7.2.1/onlyoffice-documentserver.x86_64.rpm
+	curl -sLO https://github.com/ONLYOFFICE/DocumentServer/releases/download/v7.4.1/onlyoffice-documentserver.x86_64.rpm
 	cd oo-extract && rpm2cpio ../onlyoffice-documentserver.x86_64.rpm | cpio -idm
 	chmod -R 777 oo-extract/
 	cp -r oo-extract/var/www/onlyoffice/documentserver 3rdparty/onlyoffice

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ The community document server will automatically be configured if no other docum
 
 Additionally, the community document server only supports running on x86-64 Linux servers.]]>
 	</description>
-	<version>0.1.13</version>
+	<version>0.1.14</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>DocumentServer</namespace>
@@ -31,7 +31,7 @@ Additionally, the community document server only supports running on x86-64 Linu
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/main.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/new.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="21" max-version="25"/>
+		<nextcloud min-version="21" max-version="27"/>
 	</dependencies>
 
 	<background-jobs>

--- a/lib/OnlyOffice/WebVersion.php
+++ b/lib/OnlyOffice/WebVersion.php
@@ -25,6 +25,6 @@ namespace OCA\DocumentServer\OnlyOffice;
 
 class WebVersion {
 	public function getWebUIVersion(): string {
-		return '7.4.1';
+		return '7.2.2';
 	}
 }

--- a/lib/OnlyOffice/WebVersion.php
+++ b/lib/OnlyOffice/WebVersion.php
@@ -25,6 +25,6 @@ namespace OCA\DocumentServer\OnlyOffice;
 
 class WebVersion {
 	public function getWebUIVersion(): string {
-		return '7.2.1';
+		return '7.4.1';
 	}
 }


### PR DESCRIPTION
I just tested out this on my nextcloud 27 instance and it seams to work properly. So I suggest to merge  this ASAP to make everyone able to use it :) 

I've been trying to update to last Onlyoffice version (7.4.1) but since 7.3.0, they changed a vendor sockjs to socket.io and it drops an error while trying to load a socket.io component on loading a document. I have been digging a bit and [this thread](https://forum.onlyoffice.com/t/onlyoffice-7-3-websocket-path-changed/3767/10) might help resolve this for good.