### PR TITLE
Add nextcloud 28 support

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,7 +31,7 @@ Additionally, the community document server only supports running on x86-64 Linu
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/main.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/new.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="21" max-version="27"/>
+		<nextcloud min-version="21" max-version="28"/>
 	</dependencies>
 
 	<background-jobs>

--- a/lib/Controller/StaticController.php
+++ b/lib/Controller/StaticController.php
@@ -96,8 +96,6 @@ class StaticController extends Controller {
 				$rawContent = file_get_contents($localPath);
 				$content = str_replace('__HINT__', addcslashes($hint, "'"), $rawContent);
 				return $this->createFileResponseWithContent($localPath, $content, false);
-			} elseif ($this->sessionManager->getSessionCount() >= 20) {
-				$localPath = __DIR__ . '/../../js/sessionlimit.js';
 			}
 		}
 

--- a/lib/FileResponse.php
+++ b/lib/FileResponse.php
@@ -37,7 +37,7 @@ class FileResponse extends Response implements ICallbackResponse {
 		$this->data = $data;
 		$this->name = $name;
 		$this->setStatus($statusCode);
-		$this->setHeaders(array_merge($this->getHeaders(), $headers));
+		$this->setHeaders($headers);
 		$this->addHeader('Content-Length', $length);
 		$this->addHeader('Content-Type', $mimeType);
 

--- a/lib/XHRCommand/AuthCommand.php
+++ b/lib/XHRCommand/AuthCommand.php
@@ -32,8 +32,6 @@ use OCA\DocumentServer\IPC\IIPCChannel;
 use OCA\DocumentServer\OnlyOffice\WebVersion;
 
 class AuthCommand implements ICommandHandler {
-	public const MAX_CONNECTIONS = 20;
-
 	private $changeStore;
 	private $sessionManager;
 	private $lockStore;
@@ -74,15 +72,6 @@ class AuthCommand implements ICommandHandler {
 		$session = $this->sessionManager->authenticate($session, $user['id'], $user['id'], $user['username'], $readOnly);
 
 		$participants = $this->sessionManager->getSessionsForDocument($session->getDocumentId());
-
-		if (count($participants) > self::MAX_CONNECTIONS) {
-			$sessionChannel->pushMessage(json_encode([
-				'type' => 'auth',
-				'result' => 0,
-			]));
-
-			return;
-		}
 
 		$sessionChannel->pushMessage(json_encode([
 			'type' => 'auth',

--- a/lib/XHRResponse.php
+++ b/lib/XHRResponse.php
@@ -41,7 +41,7 @@ class XHRResponse extends Response implements ICallbackResponse {
 		$this->type = $type;
 		$this->data = $data;
 		$this->setStatus($statusCode);
-		$this->setHeaders(array_merge($this->getHeaders(), $headers));
+		$this->setHeaders($headers);
 
 		$this->addHeader('Content-Type', 'application/javascript; charset=UTF-8');
 	}


### PR DESCRIPTION
Since no one else is doing it, i implemented some fixes for Nextcloud 28. Works on my machine.

May solves #310 and #306

Want to try it?
```console
sudo -i  # or su - root or whatever you need to do to become root on your box
apt update
apt install make cpio rpm2cpio curl git
cd /tmp
git clone https://github.com/WhoAmI0501/documentserver_community.git
cd documentserver_community
make
cd ..
tar cf documentserver_community.tar documentserver_community/3rdparty/ documentserver_community/appinfo/ documentserver_community/img/ documentserver_community/js/ documentserver_community/lib/ documentserver_community/README.md
cd /var/www/html/nextcloud/apps/  # or where-ever your nextcloud is installed
mv documentserver_community documentserver_community_old
tar xf /tmp/documentserver_community.tar
chown -R www-data:www-data documentserver_community  # or whatever user/group you're using
cd ..
sudo -u www-data php occ upgrade
```