### PR TITLE
CI to publish on appstore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,18 @@ jobs:
           wget https://download.nextcloud.com/server/releases/latest.zip
           unzip latest.zip
           chmod +x nextcloud/occ
-          
+      
       - name: print secrets
+        env:
+          APP_PRIVATE_KEY: ${{secrets.APP_PRIVATE_KEY}} 
+          APP_PUBLIC_CRT: ${{secrets.APP_PUBLIC_CRT}}      
         shell: bash
         run: |
-          echo "$(APP_PRIVATE_KEY)" >> $(cert_dir)/$(app_name).key
-          echo "$(APP_PUBLIC_CRT)" >> $(cert_dir)/$(app_name).crt
-          cat $(cert_dir)/$(app_name).crt
-          
+          mkdir -p ${{ env.APP_NAME }}/.cert
+          echo "$(APP_PRIVATE_KEY)" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.key
+          echo "$(APP_PUBLIC_CRT)" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
+          cat${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
+
       - name: Run build
         run: cd ${{ env.APP_NAME }} && make appstore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p ${{ env.APP_NAME }}/.cert
-          echo "$(APP_PRIVATE_KEY)" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.key
-          echo "$(APP_PUBLIC_CRT)" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
+          echo "$APP_PRIVATE_KEY" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.key
+          echo "$APP_PUBLIC_CRT" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
           cat${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
 
       - name: Run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,7 @@ env:
 jobs:
   build_and_publish:
     runs-on: ubuntu-20.04
-    env:
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-      APP_PUBLIC_CRT: ${{ secrets.APP_PUBLIC_CRT }}
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
       - name: print secrets
         shell: bash
         run: |
-          echo "$(secrets.APP_PRIVATE_KEY)" >> $(cert_dir)/$(app_name).key
-          echo "$(secrets.APP_PUBLIC_CRT)" >> $(cert_dir)/$(app_name).crt
+          echo "$(APP_PRIVATE_KEY)" >> $(cert_dir)/$(app_name).key
+          echo "$(APP_PUBLIC_CRT)" >> $(cert_dir)/$(app_name).crt
           cat $(cert_dir)/$(app_name).crt
           
       - name: Run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,15 @@ jobs:
         run: |
           wget https://download.nextcloud.com/server/releases/latest.zip
           unzip latest.zip
-          chmod +x nextcloud/occ      
-
+          chmod +x nextcloud/occ
+          
+      - name: print secrets
+        shell: bash
+        run: |
+          echo "$(secrets.APP_PRIVATE_KEY)" >> $(cert_dir)/$(app_name).key
+          echo "$(secrets.APP_PUBLIC_CRT)" >> $(cert_dir)/$(app_name).crt
+          cat $(cert_dir)/$(app_name).crt
+          
       - name: Run build
         run: cd ${{ env.APP_NAME }} && make appstore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ${{ env.APP_NAME }}
-      
+
+      - name: Download Nextcloud command line tools
+        run: |
+          wget https://download.nextcloud.com/server/releases/latest.zip
+          unzip latest.zip
+          chmod +x nextcloud/occ      
+
       - name: Run build
         run: cd ${{ env.APP_NAME }} && make appstore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,30 +10,12 @@ env:
 jobs:
   build_and_publish:
     runs-on: ubuntu-20.04
-    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           path: ${{ env.APP_NAME }}
-
-      - name: Download Nextcloud command line tools
-        run: |
-          wget https://download.nextcloud.com/server/releases/latest.zip
-          unzip latest.zip
-          chmod +x nextcloud/occ
       
-      - name: print secrets
-        env:
-          APP_PRIVATE_KEY: ${{secrets.APP_PRIVATE_KEY}} 
-          APP_PUBLIC_CRT: ${{secrets.APP_PUBLIC_CRT}}      
-        shell: bash
-        run: |
-          mkdir -p ${{ env.APP_NAME }}/.cert
-          echo "$APP_PRIVATE_KEY" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.key
-          echo "$APP_PUBLIC_CRT" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
-          cat ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
-
       - name: Run build
         run: cd ${{ env.APP_NAME }} && make appstore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           mkdir -p ${{ env.APP_NAME }}/.cert
           echo "$APP_PRIVATE_KEY" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.key
           echo "$APP_PUBLIC_CRT" >> ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
-          cat${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
+          cat ${{ env.APP_NAME }}/.cert/${{ env.APP_NAME }}.crt
 
       - name: Run build
         run: cd ${{ env.APP_NAME }} && make appstore

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ appstore:
 	echo $(APP_PUBLIC_CRT) > $(cert_dir)/$(app_name).crt
 
 	rsync -a \
-	--exclude-vcs \
 	--exclude="../$(app_name)/build" \
 	--exclude="../$(app_name)/tests" \
 	--exclude="../$(app_name)/Makefile" \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ appstore:
 
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \
 		echo "Signing app files…"; \
-		php ../../occ integrity:sign-app \
+		php ../nextcloud/occ integrity:sign-app \
 			--privateKey=$(cert_dir)/$(app_name).key\
 			--certificate=$(cert_dir)/$(app_name).crt\
 			--path=../$(app_name); \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 app_name=documentserver_community
 project_dir=$(CURDIR)/../$(app_name)
-build_dir=$(project_dir)/build/artifacts
+build_dir=$(project_dir)/build
+appstore_build_directory=$(CURDIR)/build/artifacts/appstore
+appstore_package_name=$(appstore_build_directory)/$(app_name)
 sign_dir=$(build_dir)/sign
 package_name=$(app_name)
-cert_dir=$(CURDIR)/.cert
+cert_dir=$(HOME)/.nextcloud/certificates
 
 all: 3rdparty/onlyoffice/documentserver version
 
@@ -11,11 +13,11 @@ clean:
 	rm -rf 3rdparty/onlyoffice
 	rm -rf build
 
-# appstore:
-# 	make clean
-# 	make all
-# 	rm -rf $(appstore_build_directory)
-# 	mkdir -p $(appstore_build_directory)
+appstore:
+	make clean
+	make all
+	rm -rf $(appstore_build_directory)
+	mkdir -p $(appstore_build_directory)
 	tar cvzf $(appstore_package_name).tar.gz \
 	--exclude-vcs \
 	--exclude="../$(app_name)/build" \
@@ -26,36 +28,6 @@ clean:
 	--exclude="../$(app_name)/krankerl.toml" \
 	../$(app_name) \
 
-appstore:
-	make clean
-	make all
-	rm -rf $(build_dir)
-	mkdir -p $(sign_dir)
-	mkdir -p $(cert_dir)
-	echo $(APP_PRIVATE_KEY) > $(cert_dir)/$(app_name).key
-	echo $(APP_PUBLIC_CRT) > $(cert_dir)/$(app_name).crt
-
-	@if [ -f $(cert_dir)/$(app_name).key ]; then \
-		echo "Signing app files…"; \
-		php ../nextcloud/occ integrity:sign-app \
-			--privateKey=$(cert_dir)/$(app_name).key\
-			--certificate=$(cert_dir)/$(app_name).crt\
-			--path=../$(app_name); \
-	fi
-	tar -czf $(build_dir)/$(app_name)-$(version).tar.gz \
-	--exclude-vcs \
-	--exclude="../$(app_name)/build" \
-	--exclude="../$(app_name)/tests" \
-	--exclude="../$(app_name)/Makefile" \
-	--exclude="../$(app_name)/screenshots" \
-	--exclude="../$(app_name)/.*" \
-	--exclude="../$(app_name)/krankerl.toml" \
-	../$(app_name)
-	@if [ -f $(cert_dir)/$(app_name).key ]; then \
-		echo "Signing package…"; \
-		openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name)-$(version).tar.gz | openssl base64; \
-	fi
-	rm -rf$ (cert_dir)
 
 
 3rdparty/onlyoffice/documentserver:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,21 @@ clean:
 	rm -rf 3rdparty/onlyoffice
 	rm -rf build
 
+# appstore:
+# 	make clean
+# 	make all
+# 	rm -rf $(appstore_build_directory)
+# 	mkdir -p $(appstore_build_directory)
+	tar cvzf $(appstore_package_name).tar.gz \
+	--exclude-vcs \
+	--exclude="../$(app_name)/build" \
+	--exclude="../$(app_name)/tests" \
+	--exclude="../$(app_name)/Makefile" \
+	--exclude="../$(app_name)/screenshots" \
+	--exclude="../$(app_name)/.*" \
+	--exclude="../$(app_name)/krankerl.toml" \
+	../$(app_name) \
+
 appstore:
 	make clean
 	make all
@@ -20,28 +35,27 @@ appstore:
 	echo $(APP_PRIVATE_KEY) > $(cert_dir)/$(app_name).key
 	echo $(APP_PUBLIC_CRT) > $(cert_dir)/$(app_name).crt
 
-	rsync -a \
+	@if [ -f $(cert_dir)/$(app_name).key ]; then \
+		echo "Signing app files…"; \
+		php ../../occ integrity:sign-app \
+			--privateKey=$(cert_dir)/$(app_name).key\
+			--certificate=$(cert_dir)/$(app_name).crt\
+			--path=../$(app_name); \
+	fi
+	tar -czf $(build_dir)/$(app_name)-$(version).tar.gz \
+	--exclude-vcs \
 	--exclude="../$(app_name)/build" \
 	--exclude="../$(app_name)/tests" \
 	--exclude="../$(app_name)/Makefile" \
 	--exclude="../$(app_name)/screenshots" \
 	--exclude="../$(app_name)/.*" \
 	--exclude="../$(app_name)/krankerl.toml" \
-	$(project_dir)/  $(sign_dir)/$(app_name)
-	@if [ -f $(cert_dir)/$(app_name).key ]; then \
-		echo "Signing app files…"; \
-		php ../../occ integrity:sign-app \
-			--privateKey=$(cert_dir)/$(app_name).key\
-			--certificate=$(cert_dir)/$(app_name).crt\
-			--path=$(sign_dir)/$(app_name); \
-	fi
-	tar -czf $(build_dir)/$(app_name)-$(version).tar.gz \
-		-C $(sign_dir) $(app_name)
+	../$(app_name)
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \
 		echo "Signing package…"; \
 		openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name)-$(version).tar.gz | openssl base64; \
 	fi
-	rm -rf $(cert_dir)
+	rm -rf$ (cert_dir)
 
 
 3rdparty/onlyoffice/documentserver:


### PR DESCRIPTION
New release should be pushed to appstore as soon as they are available. This CI automatically build the artifact asset and publish on appstore.

Draft PR as the publishing part can not be tested without certificate use for code signing. Currently waiting for csr nextcloud team approval.