### PR TITLE
 fix x2t librairie issue #195 

### DIFF
--- a/lib/Document/ConverterBinary.php
+++ b/lib/Document/ConverterBinary.php
@@ -51,7 +51,7 @@ class ConverterBinary {
 			$password = htmlspecialchars($password, ENT_XML1, 'UTF-8');
 			$cmd .= ' ' . escapeshellarg("<TaskQueueDataConvert><m_sPassword>$password</m_sPassword></TaskQueueDataConvert>");
 		}
-		$process = proc_open($cmd, $descriptorSpec, $pipes, self::BINARY_DIRECTORY, []);
+		$process = proc_open($cmd, $descriptorSpec, $pipes, self::BINARY_DIRECTORY, ["LD_LIBRARY_PATH" => "."]); 
 
 		@fclose($pipes[0]);
 		$output = @stream_get_contents($pipes[1]);

--- a/lib/Document/ConverterBinary.php
+++ b/lib/Document/ConverterBinary.php
@@ -51,7 +51,7 @@ class ConverterBinary {
 			$password = htmlspecialchars($password, ENT_XML1, 'UTF-8');
 			$cmd .= ' ' . escapeshellarg("<TaskQueueDataConvert><m_sPassword>$password</m_sPassword></TaskQueueDataConvert>");
 		}
-		$process = proc_open($cmd, $descriptorSpec, $pipes, self::BINARY_DIRECTORY, ["LD_LIBRARY_PATH" => "."]); 
+		$process = proc_open($cmd, $descriptorSpec, $pipes, self::BINARY_DIRECTORY, ["LD_LIBRARY_PATH" => "."]);
 
 		@fclose($pipes[0]);
 		$output = @stream_get_contents($pipes[1]);


### PR DESCRIPTION
In some cases, environment, x2t tool does not load required librairies, defining LD_LIBRARY_PATH env var fix issue #195.