### PR TITLE
Fix CLI commands

### DIFF
--- a/lib/Command/FlushChanges.php
+++ b/lib/Command/FlushChanges.php
@@ -77,8 +77,10 @@ class FlushChanges extends Base {
 						'Error while applying changes for document ' . $documentId, 
 						['exception' => $e, 'app' => 'documentserver_community']
 					);
+					return 0;
 				}
 			}
 		}
+		return 1;
 	}
 }

--- a/lib/Command/Fonts.php
+++ b/lib/Command/Fonts.php
@@ -77,6 +77,8 @@ class Fonts extends Base {
 		} catch (\Exception $e) {
 			$error = $e->getMessage();
 			$output->writeln("<error>$error</error>");
+			return 0;
 		}
+		return 1;
 	}
 }


### PR DESCRIPTION
close #278 
fix 'TypeError: Return value of "OCA\DocumentServer\Command\FlushChanges::execute()" must be of the type int, "null" returned.'
and 'TypeError: Return value of "OCA\DocumentServer\Command\Fonts::execute()" must be of the type int, "null" returned.'