### PR TITLE
todo: update to v33

### DIFF
--- a/lib/Channel/SessionManager.php
+++ b/lib/Channel/SessionManager.php
@@ -71,7 +71,8 @@ class SessionManager {
 			->from('documentserver_sess')
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)));
 
-		return QueryHelper::fetchOne($query) + 1;
+		$index = QueryHelper::fetchOne($query);
+		return ($index === false || $index === null) ? 1 : (int)$index + 1;
 	}
 
 	public function newSession(string $sessionId, int $documentId) {

--- a/lib/Channel/SessionManager.php
+++ b/lib/Channel/SessionManager.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\DocumentServer\Channel;
 
+use OCA\DocumentServer\DB\QueryHelper;
 use OCA\DocumentServer\IPC\IIPCFactory;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -45,7 +46,7 @@ class SessionManager {
 
 		$query->select($query->func()->count())
 			->from('documentserver_sess');
-		return (int)$query->execute()->fetchColumn();
+		return (int)QueryHelper::fetchOne($query);
 	}
 
 	public function getSession(string $sessionId): ?Session {
@@ -55,7 +56,7 @@ class SessionManager {
 			->from('documentserver_sess')
 			->where($query->expr()->eq('session_id', $query->createNamedParameter($sessionId)));
 
-		$row = $query->execute()->fetch();
+		$row = QueryHelper::fetchRow($query);
 		if ($row) {
 			return Session::fromRow($row);
 		} else {
@@ -70,7 +71,7 @@ class SessionManager {
 			->from('documentserver_sess')
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)));
 
-		return $query->execute()->fetchColumn() + 1;
+		return QueryHelper::fetchOne($query) + 1;
 	}
 
 	public function newSession(string $sessionId, int $documentId) {
@@ -90,7 +91,7 @@ class SessionManager {
 				'readonly' => $query->createNamedParameter(1, \PDO::PARAM_INT),
 				'user_index' => $query->createNamedParameter($userId, \PDO::PARAM_INT),
 			]);
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	public function authenticate(Session $session, string $user, string $userOriginal, string $userName, bool $readOnly): Session {
@@ -104,7 +105,7 @@ class SessionManager {
 			->set('username', $query->createNamedParameter($userName))
 			->set('readonly', $query->createNamedParameter($readOnly, \PDO::PARAM_INT))
 			->where($query->expr()->eq('session_id', $query->createNamedParameter($session->getSessionId())));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 
 		return new Session(
 			$session->getSessionId(),
@@ -124,7 +125,7 @@ class SessionManager {
 		$query->update('documentserver_sess')
 			->set('last_seen', $query->createNamedParameter($this->timeFactory->getTime(), \PDO::PARAM_INT))
 			->where($query->expr()->eq('session_id', $query->createNamedParameter($sessionId)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	private function getExpiredSessions(): array {
@@ -136,7 +137,7 @@ class SessionManager {
 		$query->select('session_id')
 			->from('documentserver_sess')
 			->where($query->expr()->lt('last_seen', $query->createNamedParameter($cutoffTime, \PDO::PARAM_INT)));
-		return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
+		return QueryHelper::fetchFirstColumn($query);
 	}
 
 	public function cleanSessions(): int {
@@ -150,7 +151,7 @@ class SessionManager {
 
 		$query->delete('documentserver_sess')
 			->where($query->expr()->in('session_id', $query->createNamedParameter($expiredSessions, IQueryBuilder::PARAM_STR_ARRAY)));
-		return $query->execute();
+		return QueryHelper::executeStatement($query);
 	}
 
 	public function isDocumentActive(int $documentId): bool {
@@ -170,7 +171,7 @@ class SessionManager {
 
 		return array_map(function (array $row) {
 			return Session::fromRow($row);
-		}, $query->execute()->fetchAll());
+		}, QueryHelper::fetchAll($query));
 	}
 
 	public function getSessionForUser(string $userId): ?Session {
@@ -180,7 +181,7 @@ class SessionManager {
 			->from('documentserver_sess')
 			->where($query->expr()->eq($query->func()->concat('user', 'user_index'), $query->createNamedParameter($userId)));
 
-		$row = $query->execute()->fetch();
+		$row = QueryHelper::fetchRow($query);
 		if ($row) {
 			return Session::fromRow($row);
 		} else {

--- a/lib/Controller/CoAuthoringController.php
+++ b/lib/Controller/CoAuthoringController.php
@@ -40,7 +40,7 @@ class CoAuthoringController extends Controller {
 				$webVersion = new WebVersion();
 				return new DataResponse(['version' => $webVersion->getWebUIVersion(), 'error' => 0]);
 			default:
-				return ['error' => 5];
+				return new DataResponse(['error' => 5]);
 		}
 	}
 }

--- a/lib/Controller/ConvertController.php
+++ b/lib/Controller/ConvertController.php
@@ -62,7 +62,7 @@ class ConvertController extends Controller {
 
 			$url = $this->urlGenerator->linkToRouteAbsolute(
 				'documentserver_community.Document.documentFile', [
-					'path' => '/convert.' . $outputtype,
+					'path' => 'convert.' . $outputtype,
 					'docId' => $documentId,
 				]
 			);

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -130,6 +130,7 @@ class DocumentController extends SessionController {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	public function documentFile(int $docId, string $path, ?bool $download) {
+		$path = ltrim($path, '/');
 		$file = $this->documentStore->openDocumentFile($docId, $path);
 
 		$response = new FileResponse(

--- a/lib/Controller/SessionController.php
+++ b/lib/Controller/SessionController.php
@@ -27,6 +27,9 @@ use OCA\DocumentServer\XHRCommand\CommandDispatcher;
 use OCA\DocumentServer\Channel\ChannelFactory;
 use OCA\DocumentServer\XHRResponse;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\IRequest;
 use OCP\Security\ISecureRandom;
 
@@ -66,11 +69,9 @@ abstract class SessionController extends Controller {
 		}, $this->getIdleHandlerClasses());
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[PublicPage]
 	public function info(?string $version, string $documentId) {
 		return [
 			'websocket' => false,
@@ -91,11 +92,9 @@ abstract class SessionController extends Controller {
 		return $dispatcher;
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[PublicPage]
 	public function xhr(?string $version, string $documentId, string $serverId, string $sessionId) {
 		$session = $this->sessionFactory->getSession($sessionId, $documentId, $this->getCommandDispatcher(), $this->getInitialResponses());
 		[$type, $data] = $session->getResponse();
@@ -103,11 +102,9 @@ abstract class SessionController extends Controller {
 		return new XHRResponse($type, $data);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[PublicPage]
 	public function xhrSend(?string $version, string $documentId, string $serverId, string $sessionId) {
 		$commands = json_decode(file_get_contents('php://input'));
 		$session = $this->sessionFactory->getSession($sessionId, $documentId, $this->getCommandDispatcher());

--- a/lib/Controller/SessionController.php
+++ b/lib/Controller/SessionController.php
@@ -27,6 +27,7 @@ use OCA\DocumentServer\XHRCommand\CommandDispatcher;
 use OCA\DocumentServer\Channel\ChannelFactory;
 use OCA\DocumentServer\XHRResponse;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
@@ -73,12 +74,12 @@ abstract class SessionController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	public function info(?string $version, string $documentId) {
-		return [
+		return new DataResponse([
 			'websocket' => false,
 			'origins' => ['*:*'],
 			'cookie_needed' => false,
 			'entropy' => (int)$this->random->generate(10, ISecureRandom::CHAR_DIGITS),
-		];
+		]);
 	}
 
 	protected function getCommandDispatcher() {
@@ -112,5 +113,7 @@ abstract class SessionController extends Controller {
 			$command = json_decode($encodedCommand, true);
 			$session->handleCommand($command);
 		}
+
+		return new DataResponse(null);
 	}
 }

--- a/lib/Controller/StaticController.php
+++ b/lib/Controller/StaticController.php
@@ -30,6 +30,9 @@ use OCA\DocumentServer\Channel\SessionManager;
 use OCA\DocumentServer\FileResponse;
 use OCA\DocumentServer\SetupCheck;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\Files\IMimeTypeDetector;
 use OCP\IRequest;
@@ -56,11 +59,9 @@ class StaticController extends Controller {
 		$this->sessionManager = $sessionManager;
 	}
 
-	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
-	 * @PublicPage
-	 */
+	#[NoCSRFRequired]
+	#[NoAdminRequired]
+	#[PublicPage]
 	public function thirdparty(string $path) {
 		if (strpos($path, '..') !== false) {
 			throw new ForbiddenException();
@@ -74,11 +75,9 @@ class StaticController extends Controller {
 		return $this->createFileResponse($localPath);
 	}
 
-	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
-	 * @PublicPage
-	 */
+	#[NoCSRFRequired]
+	#[NoAdminRequired]
+	#[PublicPage]
 	public function webApps(string $path) {
 		if (strpos($path, '..') !== false) {
 			throw new ForbiddenException();
@@ -148,11 +147,9 @@ class StaticController extends Controller {
 		return str_replace('<script', "<script nonce=\"$nonce\"", $content);
 	}
 
-	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
-	 * @PublicPage
-	 */
+	#[NoCSRFRequired]
+	#[NoAdminRequired]
+	#[PublicPage]
 	public function pluginsJSON() {
 		return "[]";
 	}

--- a/lib/Controller/StaticController.php
+++ b/lib/Controller/StaticController.php
@@ -30,6 +30,7 @@ use OCA\DocumentServer\Channel\SessionManager;
 use OCA\DocumentServer\FileResponse;
 use OCA\DocumentServer\SetupCheck;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
@@ -151,6 +152,6 @@ class StaticController extends Controller {
 	#[NoAdminRequired]
 	#[PublicPage]
 	public function pluginsJSON() {
-		return "[]";
+		return new DataResponse([]);
 	}
 }

--- a/lib/DB/QueryHelper.php
+++ b/lib/DB/QueryHelper.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2026
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DocumentServer\DB;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
+class QueryHelper {
+	public static function fetchOne(IQueryBuilder $query) {
+		if (method_exists($query, 'executeQuery')) {
+			return $query->executeQuery()->fetchOne();
+		}
+
+		return $query->execute()->fetchColumn();
+	}
+
+	public static function fetchRow(IQueryBuilder $query) {
+		if (method_exists($query, 'executeQuery')) {
+			return $query->executeQuery()->fetchAssociative();
+		}
+
+		return $query->execute()->fetch();
+	}
+
+	public static function fetchAll(IQueryBuilder $query): array {
+		if (method_exists($query, 'executeQuery')) {
+			return $query->executeQuery()->fetchAllAssociative();
+		}
+
+		return $query->execute()->fetchAll();
+	}
+
+	public static function fetchFirstColumn(IQueryBuilder $query): array {
+		if (method_exists($query, 'executeQuery')) {
+			return $query->executeQuery()->fetchFirstColumn();
+		}
+
+		return $query->execute()->fetchAll(\PDO::FETCH_COLUMN);
+	}
+
+	public static function executeStatement(IQueryBuilder $query): int {
+		if (method_exists($query, 'executeStatement')) {
+			return $query->executeStatement();
+		}
+
+		return $query->execute();
+	}
+}

--- a/lib/Document/ChangeStore.php
+++ b/lib/Document/ChangeStore.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\DocumentServer\Document;
 
+use OCA\DocumentServer\DB\QueryHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
 
@@ -64,7 +65,7 @@ class ChangeStore {
 				'user' => $query->createNamedParameter($user),
 				'user_original' => $query->createNamedParameter($userOriginal),
 			]);
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	public function getMaxChangeIndexForDocument(int $documentId): int {
@@ -73,9 +74,9 @@ class ChangeStore {
 		$query->select($query->func()->max('change_index'))
 			->from('documentserver_changes')
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)));
-		$index = $query->execute()->fetchColumn();
+		$index = QueryHelper::fetchOne($query);
 
-		return ($index === false) ? -1 : (int)$index;
+		return ($index === false || $index === null) ? -1 : (int)$index;
 	}
 
 	public function getChangesForDocument(int $documentId): array {
@@ -85,7 +86,7 @@ class ChangeStore {
 			->from('documentserver_changes')
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)))
 			->orderBy('change_id', 'ASC');
-		$rows = $query->execute()->fetchAll();
+		$rows = QueryHelper::fetchAll($query);
 		return array_map([Change::class, 'fromRow'], $rows);
 	}
 
@@ -95,7 +96,7 @@ class ChangeStore {
 		$query->update('documentserver_changes')
 			->set('processing', $query->createNamedParameter(true, \PDO::PARAM_BOOL))
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 
 		$query = $this->connection->getQueryBuilder();
 
@@ -104,7 +105,7 @@ class ChangeStore {
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)))
 			->andWhere($query->expr()->eq('processing', $query->createNamedParameter(true, \PDO::PARAM_INT)))
 			->orderBy('change_id', 'ASC');
-		$rows = $query->execute()->fetchAll();
+		$rows = QueryHelper::fetchAll($query);
 		return array_map([Change::class, 'fromRow'], $rows);
 	}
 
@@ -114,7 +115,7 @@ class ChangeStore {
 		$query->update('documentserver_changes')
 			->set('processing', $query->createNamedParameter(false, \PDO::PARAM_BOOL))
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	public function deleteProcessedChanges(int $documentId) {
@@ -123,7 +124,7 @@ class ChangeStore {
 		$query->delete('documentserver_changes')
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)))
 			->andWhere($query->expr()->eq('processing', $query->createNamedParameter(true, \PDO::PARAM_INT)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	public function deleteChangesByIndex(int $documentId, int $changeIndex) {
@@ -132,6 +133,6 @@ class ChangeStore {
 		$query->delete('documentserver_changes')
 			->where($query->expr()->eq('document_id', $query->createNamedParameter($documentId, \PDO::PARAM_INT)))
 			->andWhere($query->expr()->gte('change_index', $query->createNamedParameter($changeIndex, \PDO::PARAM_INT)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 }

--- a/lib/Document/LockStore.php
+++ b/lib/Document/LockStore.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\DocumentServer\Document;
 
+use OCA\DocumentServer\DB\QueryHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -50,7 +51,7 @@ class LockStore {
 				"time" => $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT),
 				"block" => $query->createNamedParameter(json_encode($block)),
 			]);
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	/**
@@ -63,7 +64,7 @@ class LockStore {
 			->from("documentserver_locks")
 			->where($query->expr()->eq("document_id",
 				$query->createNamedParameter($document, IQueryBuilder::PARAM_INT)));
-		$rows = $query->execute()->fetchAll();
+		$rows = QueryHelper::fetchAll($query);
 
 		$locks = array_map([Lock::class, "fromRow"], $rows);
 		$keys = array_map(function (Lock $lock, $key) {
@@ -78,7 +79,7 @@ class LockStore {
 	}
 
 	private function releaseLocksByQuery(IQueryBuilder $query): array {
-		$rows = $query->execute()->fetchAll();
+		$rows = QueryHelper::fetchAll($query);
 
 		$released = array_map([Lock::class, "fromRow"], $rows);
 
@@ -90,7 +91,7 @@ class LockStore {
 		$query->delete("documentserver_locks")
 			->where($query->expr()->in("lock_id",
 				$query->createNamedParameter($lockIds, IQueryBuilder::PARAM_INT_ARRAY)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 
 		return $released;
 	}
@@ -128,6 +129,6 @@ class LockStore {
 		$query->delete("documentserver_locks")
 			->where($query->expr()->lt("time",
 				$query->createNamedParameter($this->timeFactory->getTime() - self::TIMEOUT, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 }

--- a/lib/IPC/DatabaseIPCBackend.php
+++ b/lib/IPC/DatabaseIPCBackend.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\DocumentServer\IPC;
 
+use OCA\DocumentServer\DB\QueryHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -46,7 +47,7 @@ class DatabaseIPCBackend implements IIPCBackend {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('documentserver_ipc')
 			->where($query->expr()->eq('session_id', $query->createNamedParameter($channel)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	public function pushMessage(string $channel, string $message) {
@@ -57,7 +58,7 @@ class DatabaseIPCBackend implements IIPCBackend {
 				'time' => $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT),
 				'message' => $query->createNamedParameter($message),
 			]);
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 
 	public function popMessage(string $channel, int $timeout): ?string {
@@ -68,11 +69,11 @@ class DatabaseIPCBackend implements IIPCBackend {
 			->orderBy('message_id', 'ASC')
 			->setMaxResults(1);
 
-		if ($row = $query->execute()->fetch()) {
+		if ($row = QueryHelper::fetchRow($query)) {
 			$query = $this->connection->getQueryBuilder();
 			$query->delete('documentserver_ipc')
 				->where($query->expr()->eq('message_id', $query->createNamedParameter($row['message_id'], IQueryBuilder::PARAM_INT)));
-			$deleted = $query->execute();
+			$deleted = QueryHelper::executeStatement($query);
 
 			// if we didn't delete the row there was a race we lost, so we'll try again later
 			if ($deleted === 1) {
@@ -88,6 +89,6 @@ class DatabaseIPCBackend implements IIPCBackend {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('documentserver_ipc')
 			->where($query->expr()->lt('time', $query->createNamedParameter($this->timeFactory->getTime() - self::TIMEOUT, IQueryBuilder::PARAM_INT)));
-		$query->execute();
+		QueryHelper::executeStatement($query);
 	}
 }

--- a/lib/OnlyOffice/AutoConfig.php
+++ b/lib/OnlyOffice/AutoConfig.php
@@ -31,6 +31,7 @@ class AutoConfig {
 		'odp',
 		'ods',
 		'odt',
+		'pdf',
 		'ppt',
 		'pptx',
 		'xls',

--- a/lib/OnlyOffice/AutoConfig.php
+++ b/lib/OnlyOffice/AutoConfig.php
@@ -117,6 +117,16 @@ class AutoConfig {
 		if (!$forceWrite && !$hasUnsupportedFormats) {
 			return;
 		}
+		// On initial config, enable all supported formats regardless of what FormatsSetting returns,
+		// so a fresh install does not end up with zero formats enabled.
+		if ($forceWrite) {
+			foreach (self::SUPPORTED_DEFAULT_FORMATS as $format) {
+				$defaultFormats[$format] = true;
+			}
+			foreach (self::SUPPORTED_EDIT_FORMATS as $format) {
+				$editFormats[$format] = true;
+			}
+		}
 
 		$this->appConfig->SetDefaultFormats($defaultFormats);
 		$this->appConfig->SetEditableFormats($editFormats);

--- a/lib/OnlyOffice/AutoConfig.php
+++ b/lib/OnlyOffice/AutoConfig.php
@@ -25,6 +25,33 @@ use OCA\Onlyoffice\AppConfig;
 use OCP\IURLGenerator;
 
 class AutoConfig {
+	private const SUPPORTED_DEFAULT_FORMATS = [
+		'doc',
+		'docx',
+		'odp',
+		'ods',
+		'odt',
+		'ppt',
+		'pptx',
+		'xls',
+		'xlsx',
+	];
+
+	private const SUPPORTED_EDIT_FORMATS = [
+		'csv',
+		'doc',
+		'docx',
+		'odp',
+		'ods',
+		'odt',
+		'ppt',
+		'pptx',
+		'rtf',
+		'txt',
+		'xls',
+		'xlsx',
+	];
+
 	private $urlGenerator;
 	private $appConfig;
 
@@ -36,6 +63,8 @@ class AutoConfig {
 	public function autoConfigIfNeeded() {
 		if ($this->shouldAutoConfig()) {
 			$this->autoConfig();
+		} elseif ($this->isCommunityDocumentServerConfigured()) {
+			$this->syncSupportedFormats(false);
 		}
 	}
 
@@ -48,6 +77,10 @@ class AutoConfig {
 		return !$this->appConfig->GetDocumentServerUrl();
 	}
 
+	private function isCommunityDocumentServerConfigured(): bool {
+		return strpos((string)$this->appConfig->GetDocumentServerUrl(), 'apps/documentserver_community') !== false;
+	}
+
 	/**
 	 * Fill the documentserver url and other defaults
 	 */
@@ -56,29 +89,35 @@ class AutoConfig {
 			['path' => '_']), 0, -strlen('/web-apps/_'));
 		$this->appConfig->SetDocumentServerUrl($url);
 
-		$formatSettings = $this->appConfig->FormatsSetting();
-		$defaultFormats = array_map(function ($settings) {
-			return $settings["def"] ?? false;
-		}, $formatSettings);
-		$editFormats = array_map(function ($settings) {
-			return $settings["edit"] ?? false;
-		}, $formatSettings);
+		$this->syncSupportedFormats(true);
+		$this->appConfig->SetSameTab(true);
+	}
 
-		$defaultFormats = array_merge(
-			array_filter($defaultFormats, function ($settings) {
-				return $settings;
-			}),
-			["odp" => true, "ods" => true, "odt" => true, "pptx" => true, "xlsx" => true, "docx" => true, "doc" => true, "ppt" => true, "xls" => true]
-		);
-		$editFormats = array_merge(
-			array_filter($editFormats, function ($settings) {
-				return $settings;
-			}),
-			["csv" => true, "odp" => true, "ods" => true, "odt" => true, "rtf" => true, "txt" => true]
-		);
+	private function syncSupportedFormats(bool $forceWrite): void {
+		$formatSettings = $this->appConfig->FormatsSetting();
+		$defaultFormats = [];
+		$editFormats = [];
+		$hasUnsupportedFormats = false;
+
+		foreach ($formatSettings as $format => $settings) {
+			if (!in_array($format, self::SUPPORTED_DEFAULT_FORMATS, true) && ($settings['def'] ?? false)) {
+				$hasUnsupportedFormats = true;
+			}
+			if (!in_array($format, self::SUPPORTED_EDIT_FORMATS, true) && ($settings['edit'] ?? false)) {
+				$hasUnsupportedFormats = true;
+			}
+
+			$defaultFormats[$format] = in_array($format, self::SUPPORTED_DEFAULT_FORMATS, true)
+				&& ($settings['def'] ?? false);
+			$editFormats[$format] = in_array($format, self::SUPPORTED_EDIT_FORMATS, true)
+				&& ($settings['edit'] ?? false);
+		}
+
+		if (!$forceWrite && !$hasUnsupportedFormats) {
+			return;
+		}
 
 		$this->appConfig->SetDefaultFormats($defaultFormats);
 		$this->appConfig->SetEditableFormats($editFormats);
-		$this->appConfig->SetSameTab(true);
 	}
 }

--- a/tests/Channel/SessionManagerTest.php
+++ b/tests/Channel/SessionManagerTest.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace OCA\DocumentServer\Tests\Channel;
 
+use OCA\DocumentServer\DB\QueryHelper;
+use OCA\DocumentServer\IPC\IIPCFactory;
 use OCA\DocumentServer\Channel\SessionManager;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
@@ -37,6 +39,8 @@ class SessionManagerTest extends TestCase {
 	private $connection;
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
+	/** @var IIPCFactory|MockObject */
+	private $ipcFactory;
 	/** @var SessionManager */
 	private $manager;
 
@@ -47,12 +51,13 @@ class SessionManagerTest extends TestCase {
 
 		$this->connection = \OC::$server->getDatabaseConnection();
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->ipcFactory = $this->createMock(IIPCFactory::class);
 		$this->timeFactory->method('getTime')
 			->willReturnCallback(function () {
 				return $this->time;
 			});
 
-		$this->manager = new SessionManager($this->connection, $this->timeFactory);
+		$this->manager = new SessionManager($this->connection, $this->timeFactory, $this->ipcFactory);
 	}
 
 	public function testNewGet() {
@@ -84,7 +89,8 @@ class SessionManagerTest extends TestCase {
 
 	protected function tearDown(): void {
 		$query = $this->connection->getQueryBuilder();
-		$query->delete('documentserver_sess')->execute();
+		$query->delete('documentserver_sess');
+		QueryHelper::executeStatement($query);
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
Hiya! I started working on moving this project over to v33. This is some beginning that makes the Plugin comaptible with the recent changes in v33. There are however still alot of issues with it, but atleast it doesnt complain anymore.

**Nextcloud 33 query API compatibility**
Add a small query helper that abstracts executeQuery / executeStatement vs legacy execute().
Update session, change, lock, and IPC storage paths to use the compatibility layer instead of direct deprecated calls.

**Supported format auto-configuration**
Restrict community auto-configuration to the format set supported by the bundled document server.
Preserve ONLYOFFICE’s discovered format matrix, but filter default/editable selections to known-safe extensions.
Re-sync existing community-document-server installs when unsupported formats are currently enabled, preventing invalid documentType configs from being generated.