### PR TITLE
Fix boot failure on Nextcloud 34, support onlyoffice connector >= 10.1, and fix PHP 8.4 nullable deprecations

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,7 +31,7 @@ Additionally, the community document server only supports running on x86-64 Linu
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/main.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/documentserver_community/master/screenshots/new.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="21" max-version="33"/>
+		<nextcloud min-version="21" max-version="34"/>
 	</dependencies>
 
 	<background-jobs>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -62,7 +62,7 @@ class Application extends App implements IBootstrap {
 
 		$context->registerService(URLDecoder::class, function (IAppContainer $container) {
 			$server = $container->getServer();
-			$appConfig = new AppConfig('onlyoffice', \OC::$server->getConfig(), \OCP\Log\logger('onlyoffice'), \OC::$server->get(ICacheFactory::class));
+			$appConfig = $this->buildAppConfig();
 			$crypto = new Crypt($appConfig);
 
 			return new URLDecoder(
@@ -75,12 +75,41 @@ class Application extends App implements IBootstrap {
 
 		$context->registerService(AutoConfig::class, function (IAppContainer $container) {
 			$server = $container->getServer();
-			$appConfig = new AppConfig('onlyoffice', \OC::$server->getConfig(), \OCP\Log\logger('onlyoffice'), \OC::$server->get(ICacheFactory::class));
+			$appConfig = $this->buildAppConfig();
 			return new AutoConfig(
 				$server->get(IURLGenerator::class),
 				$appConfig
 			);
 		});
+	}
+
+	/**
+	 * Build an onlyoffice AppConfig instance regardless of the connector version.
+	 *
+	 * The onlyoffice connector changed AppConfig's constructor signature over
+	 * time: up to 10.0 it was (string, IConfig, LoggerInterface, ICacheFactory);
+	 * from 10.1 it became (string, IAppConfig, IConfig, IUserConfig,
+	 * LoggerInterface, ICacheFactory). Detect the arity and pass accordingly so
+	 * this app keeps booting across connector and Nextcloud versions.
+	 */
+	private function buildAppConfig(): AppConfig {
+		$config = \OC::$server->getConfig();
+		$logger = \OCP\Log\logger('onlyoffice');
+		$cacheFactory = \OC::$server->get(ICacheFactory::class);
+
+		$paramCount = (new \ReflectionMethod(AppConfig::class, '__construct'))->getNumberOfParameters();
+		if ($paramCount >= 6) {
+			return new AppConfig(
+				'onlyoffice',
+				\OC::$server->get(\OCP\IAppConfig::class),
+				$config,
+				\OC::$server->get(\OCP\Config\IUserConfig::class),
+				$logger,
+				$cacheFactory
+			);
+		}
+
+		return new AppConfig('onlyoffice', $config, $logger, $cacheFactory);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -93,7 +93,7 @@ class Application extends App implements IBootstrap {
 	 * this app keeps booting across connector and Nextcloud versions.
 	 */
 	private function buildAppConfig(): AppConfig {
-		$config = \OC::$server->getConfig();
+		$config = \OC::$server->get(\OCP\IConfig::class);
 		$logger = \OCP\Log\logger('onlyoffice');
 		$cacheFactory = \OC::$server->get(ICacheFactory::class);
 

--- a/lib/Document/ConverterBinary.php
+++ b/lib/Document/ConverterBinary.php
@@ -34,7 +34,7 @@ class ConverterBinary {
 		$this->logger = $logger;
 	}
 
-	public function run(string $param, string $password = null): string {
+	public function run(string $param, ?string $password = null): string {
 		if (!is_executable(self::BINARY_DIRECTORY . '/x2t')) {
 			@chmod(self::BINARY_DIRECTORY . '/x2t', 0755);
 		}

--- a/lib/Document/DocumentStore.php
+++ b/lib/Document/DocumentStore.php
@@ -73,7 +73,7 @@ class DocumentStore {
 		}
 	}
 
-	public function getDocumentForEditor(int $documentId, File $sourceFile, string $sourceFormat, string $password = null): ISimpleFile {
+	public function getDocumentForEditor(int $documentId, File $sourceFile, string $sourceFormat, ?string $password = null): ISimpleFile {
 		$docFolder = $this->getDocumentFolder($documentId);
 		try {
 			return $docFolder->getFile('Editor.bin');

--- a/lib/DocumentConverter.php
+++ b/lib/DocumentConverter.php
@@ -42,7 +42,7 @@ class DocumentConverter {
 		$this->converter = $converterBinary;
 	}
 
-	public function getEditorBinary($source, string $sourceExtension, string $targetFolder, string $password = null) {
+	public function getEditorBinary($source, string $sourceExtension, string $targetFolder, ?string $password = null) {
 		$sourceFile = $this->tempManager->getTemporaryFile(".$sourceExtension");
 		file_put_contents($sourceFile, $source);
 
@@ -106,14 +106,14 @@ class DocumentConverter {
 	}
 
 
-	public function convertFiles(string $from, string $to, int $targetFormat = DocumentFormat::AVS_OFFICESTUDIO_FILE_CANVAS, string $password = null) {
+	public function convertFiles(string $from, string $to, int $targetFormat = DocumentFormat::AVS_OFFICESTUDIO_FILE_CANVAS, ?string $password = null) {
 		$command = new ConvertCommand($from, $to);
 		$command->setTargetFormat($targetFormat);
 
 		$this->runCommand($command, $password);
 	}
 
-	public function runCommand(ConvertCommand $command, string $password = null) {
+	public function runCommand(ConvertCommand $command, ?string $password = null) {
 		$xmlFile = $this->tempManager->getTemporaryFile('.xml');
 		$xmlWriter = new Writer();
 		$xmlWriter->namespaceMap["http://www.w3.org/2001/XMLSchema-instance"] = "xsi";


### PR DESCRIPTION
## What

Four related fixes that let `documentserver_community` boot and run on Nextcloud 34 and with the current ONLYOFFICE connector on recent PHP.

On Nextcloud 34 the app currently fails to boot on **every request**, so this is not only a connector >= 10.1 issue.

### 1. Fix boot failure on Nextcloud 34 (`getConfig()` removed)

`OC\Server::getConfig()` no longer exists on NC 34, so the `new AppConfig('onlyoffice', \OC::$server->getConfig(), ...)` calls in `Application.php` break the app on every request:

```
Could not boot documentserver_community: Call to undefined method OC\Server::getConfig()
```

Visible symptoms: HTTP 500 on `/apps/documentserver_community/healthcheck`, and "Error when trying to connect" on the admin page.

`IConfig` is now resolved through the DI container (`\OC::$server->get(\OCP\IConfig::class)`) instead of the removed accessor. Same service, no behaviour change.

Credit to @sjs6776 and @defame-flagstick, who diagnosed this and posted the fix in the comments.

### 2. Support ONLYOFFICE connector >= 10.1 (AppConfig constructor change)

Once the boot failure above is fixed, the next blocker is the connector's constructor signature. `OCA\Onlyoffice\AppConfig::__construct` changed in 10.1 from

```
(string $appName, IConfig, LoggerInterface, ICacheFactory)                            // <= 10.0
```

to

```
(string $appName, IAppConfig, IConfig, IUserConfig, LoggerInterface, ICacheFactory)   // >= 10.1
```

With the old 4-argument call the app no longer boots:

```
TypeError: OCA\Onlyoffice\AppConfig::__construct(): Argument #2 ($appConfig)
must be of type OCP\IAppConfig, OC\AllConfig given
```

A new `buildAppConfig()` helper detects the constructor arity at runtime via reflection and passes the matching arguments, so it keeps working with both the old (<= 10.0) and the new (>= 10.1) connector, and with the Nextcloud versions that ship them (`OCP\Config\IUserConfig` only exists on the newer ones). The two duplicated inline constructions are replaced by calls to this helper.

### 3. PHP 8.4 — explicit nullable parameter types

PHP 8.4 deprecates implicitly nullable parameters (`Type $x = null`). Made the nullable explicit (`?Type`) for the `$password` parameters in `DocumentConverter`, `ConverterBinary` and `DocumentStore`. No behaviour change; removes the deprecation warnings logged on every document conversion.

### 4. Allow installation on Nextcloud 34

`appinfo/info.xml` still declared `max-version="33"`, so even with the fixes above the app would not be offered on NC 34. Bumped to `max-version="34"`.

## Changed files

| File | Change |
| --- | --- |
| `lib/AppInfo/Application.php` | `buildAppConfig()` helper: DI-resolved `IConfig` + connector arity detection |
| `lib/DocumentConverter.php` | explicit `?Type` on `$password` |
| `lib/Document/ConverterBinary.php` | explicit `?Type` on `$password` |
| `lib/Document/DocumentStore.php` | explicit `?Type` on `$password` |
| `appinfo/info.xml` | `max-version` 33 → 34 |

## Testing

Verified on **Nextcloud 33.0.5 / PHP 8.4 / connector 10.1.0**: the app boots, `/healthcheck` returns 200, documents open and convert.

Independently reported on **Nextcloud 34.0.1 / PHP 8.3.31 / connector 10.1.2 / documentserver_community 0.2.4** by @blueforce: the app boots cleanly, `/healthcheck` returns `true`, the boot errors disappear from the log, and opening/editing `.docx` and `.xlsx` works with no errors. To be precise about scope: that confirmation was obtained with the equivalent fix applied by hand (`\OC::$server->get(\OCP\IConfig::class)` plus the 6-argument constructor), not with this branch checked out verbatim.

## Note

I have since migrated to a different setup and won't be actively testing or maintaining this going forward. The PR is left open in case it is useful; happy for a maintainer to take it over or push to the branch.
