### PR TITLE
Fix editor stuck on "Loading document" when appdata is on local storage

### DIFF
--- a/lib/Controller/ConvertController.php
+++ b/lib/Controller/ConvertController.php
@@ -23,13 +23,16 @@ declare(strict_types=1);
 
 namespace OCA\DocumentServer\Controller;
 
+use OCA\DocumentServer\Document\DocumentConversionException;
 use OCA\DocumentServer\Document\DocumentStore;
+use OCA\DocumentServer\Document\PasswordRequiredException;
 use OCA\DocumentServer\OnlyOffice\URLDecoder;
 use OCA\DocumentServer\JSONResponse;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class ConvertController extends Controller {
@@ -37,7 +40,14 @@ class ConvertController extends Controller {
 	private $urlDecoder;
 	private $urlGenerator;
 
-	public function __construct(DocumentStore $documentStore, URLDecoder $urlDecoder, IURLGenerator $urlGenerator) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		DocumentStore $documentStore,
+		URLDecoder $urlDecoder,
+		IURLGenerator $urlGenerator
+	) {
+		parent::__construct($appName, $request);
 		$this->documentStore = $documentStore;
 		$this->urlDecoder = $urlDecoder;
 		$this->urlGenerator = $urlGenerator;
@@ -57,8 +67,22 @@ class ConvertController extends Controller {
 		} else {
 			$documentId = (int)$key;
 			$documentFile = $this->urlDecoder->getFileForUrl($url);
-			$this->documentStore->getDocumentForEditor($documentId, $documentFile, $filetype);
-			$this->documentStore->convert($documentId, $outputtype);
+
+			// A failed conversion must come back as a structured {"error": <code>}
+			// body, not as an uncaught exception: this is a plain HTTP endpoint
+			// with no other handler, so without this catch the converter's
+			// exception escapes as a 500 the caller can't interpret. This endpoint
+			// answers the connector over the server-side conversion API, whose
+			// error codes differ from the editor's c_oAscError space used in the
+			// socket replies: -5 incorrect password, -3 conversion error.
+			try {
+				$this->documentStore->getDocumentForEditor($documentId, $documentFile, $filetype);
+				$this->documentStore->convert($documentId, $outputtype);
+			} catch (PasswordRequiredException $e) {
+				return new JSONResponse(['error' => -5]);
+			} catch (DocumentConversionException $e) {
+				return new JSONResponse(['error' => -3]);
+			}
 
 			$url = $this->urlGenerator->linkToRouteAbsolute(
 				'documentserver_community.Document.documentFile', [

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -187,7 +187,47 @@ class DocumentController extends Controller {
 	public function download(int $docId, string $cmd) {
 		$cmd = json_decode($cmd, true);
 		$content = fopen('php://input', 'r');
-		$title = $this->documentStore->convertForDownload($docId, $content, $cmd);
+
+		// A failed save-as conversion must be reported to the editor as a 'save'
+		// error, not escape as an uncaught 500: this endpoint has no other
+		// handler, and the editor is waiting on a documentOpen 'save' reply. Tell
+		// the session it failed (-4 = sdkjs DownloadError) so the user sees a
+		// failed download instead of a silent hang, then return the same error to
+		// the HTTP caller. The reply push is itself guarded: if the IPC backend is
+		// what failed, getChannel() would throw and re-raise an uncaught 500.
+		try {
+			$title = $this->documentStore->convertForDownload($docId, $content, $cmd);
+		} catch (\Exception $e) {
+			$this->logger->warning('documentserver download conversion error: {error}', [
+				'error' => $e->getMessage(),
+				'exception' => $e,
+			]);
+
+			try {
+				$session = $this->sessionManager->getSessionForUser($cmd['userconnectionid']);
+				if ($session) {
+					$this->ipcFactory->getChannel($session->getSessionId())->pushMessage(json_encode([
+						'type' => 'documentOpen',
+						'data' => [
+							'type' => 'save',
+							'status' => 'err',
+							'data' => -4,
+						],
+					]));
+				}
+			} catch (\Exception $replyError) {
+				$this->logger->warning('documentserver download could not deliver error reply: {error}', [
+					'error' => $replyError->getMessage(),
+					'exception' => $replyError,
+				]);
+			}
+
+			return new DataResponse([
+				'type' => 'save',
+				'status' => 'err',
+				'data' => -4,
+			]);
+		}
 
 		$session = $this->sessionManager->getSessionForUser($cmd['userconnectionid']);
 		if ($session) {
@@ -361,6 +401,35 @@ class DocumentController extends Controller {
 					'error' => $e->getMessage(),
 					'exception' => $e,
 				]);
+
+				// Don't let a failed command (e.g. the document failing to
+				// open) disappear into the log: with no reply the editor stays
+				// on "Loading document" forever. Push a documentOpen error so
+				// the client surfaces it instead of spinning. Same message shape
+				// the client already handles for the password case in
+				// OpenDocument::openDocument; sdkjs parses data as a
+				// c_oAscError.ID and shows the matching error, -4 is
+				// DownloadError ("download failed"), the closest generic
+				// open-failure code. Guard the reply itself: if the original
+				// failure was the IPC backend being unavailable, getChannel()
+				// throws too, and an unguarded re-throw here would turn the
+				// swallowed error back into an uncaught 500.
+				try {
+					$sessionChannel = $this->ipcFactory->getChannel($sid);
+					$sessionChannel->pushMessage(json_encode([
+						'type' => 'documentOpen',
+						'data' => [
+							'type' => 'open',
+							'status' => 'err',
+							'data' => -4,
+						],
+					]));
+				} catch (\Exception $replyError) {
+					$this->logger->warning('documentserver socketIO could not deliver error reply: {error}', [
+						'error' => $replyError->getMessage(),
+						'exception' => $replyError,
+					]);
+				}
 			}
 		}
 		// sio types '0' (CONNECT) and '1' (DISCONNECT) require no action here.

--- a/lib/Document/ConverterBinary.php
+++ b/lib/Document/ConverterBinary.php
@@ -53,6 +53,14 @@ class ConverterBinary {
 		}
 		$process = proc_open($cmd, $descriptorSpec, $pipes, self::BINARY_DIRECTORY, ["LD_LIBRARY_PATH" => "."]);
 
+		// proc_open returns false if x2t couldn't be spawned at all (missing
+		// binary, fork failure). Without this the next lines fclose/read null
+		// pipes and proc_close(false) warns, and the caller silently gets no
+		// output instead of a clear failure.
+		if ($process === false) {
+			throw new DocumentConversionException("failed to start x2t");
+		}
+
 		@fclose($pipes[0]);
 		$output = @stream_get_contents($pipes[1]);
 		$error = @stream_get_contents($pipes[2]);
@@ -65,9 +73,18 @@ class ConverterBinary {
 
 		if ($error) {
 			throw new DocumentConversionException($error);
-		} else {
-			return $output;
 		}
+
+		// x2t can fail with a nonzero exit status while writing nothing to stderr;
+		// without this the caller treats a failed conversion as success and later
+		// trips over the missing Editor.bin, see #70. Stderr is checked first so its
+		// (more specific) message wins, including the "Empty sFileFrom or sFileTo"
+		// string that test() relies on.
+		if ($status !== 0) {
+			throw new DocumentConversionException("x2t exited with status $status");
+		}
+
+		return $output;
 	}
 
 	public function test(): bool {

--- a/lib/LocalAppData.php
+++ b/lib/LocalAppData.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\DocumentServer;
 
+use OCP\Files\Cache\IScanner;
 use OCP\Files\Folder;
 use OCP\Files\File;
 use OCP\Files\IAppData;
@@ -30,6 +31,8 @@ use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;
 use OCP\ITempManager;
+use OCP\Lock\LockedException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Provide local access to appdata folders
@@ -38,15 +41,18 @@ class LocalAppData {
 	private $appData;
 	private $config;
 	private $tmpManager;
+	private LoggerInterface $logger;
 
 	public function __construct(
 		IAppData $appData,
 		IConfig $config,
-		ITempManager $tmpManager
+		ITempManager $tmpManager,
+		LoggerInterface $logger
 	) {
 		$this->appData = $appData;
 		$this->config = $config;
 		$this->tmpManager = $tmpManager;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -100,6 +106,33 @@ class LocalAppData {
 
 		if (is_dir($localPath)) {
 			$callback($localPath);
+			// The callback (e.g. x2t producing Editor.bin) writes straight to the
+			// on-disk appdata folder, bypassing the Nextcloud storage layer, so the
+			// file cache never learns about the new files and a later getFile() would
+			// throw NotFoundException. Rescan the folder so the writes become visible,
+			// see #70 (editor stuck on "Loading document" because Editor.bin is on disk
+			// but absent from oc_filecache). The temp-folder branch below does not need
+			// this because copyFromLocal() writes back through File::putContent(),
+			// which updates the cache itself. The scan must be RECURSIVE: x2t emits
+			// not just Editor.bin but a media/ subfolder of embedded images, and
+			// the open flow reads those back through the file API
+			// (DocumentStore::getEmbeddedFiles -> media/.getDirectoryListing()). A
+			// shallow scan would register Editor.bin but leave media/'s children
+			// uncached, so embedded images would silently fail to load. A
+			// concurrent writer can hold the scan lock; mirror NC core's
+			// backgroundScan and skip rather than fail the open, the next access
+			// rescans.
+			try {
+				$fullFolder->getStorage()->getScanner()->scan(
+					$fullFolder->getInternalPath(),
+					IScanner::SCAN_RECURSIVE
+				);
+			} catch (LockedException $e) {
+				$this->logger->warning(
+					'documentserver: appdata rescan after conversion skipped, folder locked',
+					['exception' => $e, 'app' => 'documentserver_community']
+				);
+			}
 		} else {
 			$localPath = $this->tmpManager->getTemporaryFolder();
 			$this->copyToLocal($fullFolder, $localPath);


### PR DESCRIPTION
## The bug

When the appdata folder is on local storage, opening a document hangs on "Loading document" forever.

The conversion itself is fine: x2t produces a valid `Editor.bin` and a `media/` folder of embedded images. The problem is that nobody tells Nextcloud's file cache they exist. `LocalAppData::getReadWriteLocalPath` has two branches, and the local-storage one (`is_dir`) runs the converter directly against the on-disk path and returns without calling `copyFromLocal()`. So the converter writes its output straight to disk, underneath the storage layer, and the file cache never hears about it. The next read, `DocumentStore::getFile('Editor.bin')` (and the `getDirectoryListing()` on `media/` for the embedded images), goes through the file cache rather than stat-ing the disk, so it throws `OCP\Files\NotFoundException` for files that are sitting right there. That exception gets swallowed, the editor never receives its `documentOpen` reply, and it spins.

This is the same missing-`Editor.bin` `NotFoundException` reported for CSV in #70 (closed). It was never really about CSV: it hits any document on local-storage appdata, on open, save-as, and convert alike. On object-store appdata the other branch runs, which writes back through `File::putContent` and updates the cache, so none of this applies there.

## The fix

The core of it is in `LocalAppData::getReadWriteLocalPath`: after the in-place callback runs, rescan the folder so the cache learns about what the converter just wrote. The rescan has to be recursive, because the open path reads the embedded images out of `media/` via `getDirectoryListing()`, and a shallow scan would register `Editor.bin` but leave `media/`'s children invisible. If a concurrent writer is holding the scan lock, the `LockedException` is logged and skipped rather than failing the open; the next access will rescan anyway.

The rest of the change is about not hiding failures, since the stall was so hard to track down precisely because the failure was silent. `ConverterBinary::run` now throws if `proc_open` returns `false`, and throws on a non-zero x2t exit instead of only on non-empty stderr, so a broken conversion can never be mistaken for a successful one. (Stderr is still checked first so its more specific message wins, including the `Empty sFileFrom or sFileTo` string that `test()` depends on.)

With the converter now able to throw, the three callers have to report it instead of swallowing it or letting it become an HTTP 500 response. On the socketIO open path, `DocumentController` pushes a `documentOpen` error so the editor shows something instead of spinning; that reply is itself wrapped, because if the IPC backend is the thing that died, `getChannel()` throws too and an unguarded re-throw would just turn the swallowed error back into a 500 response. The download (save-as) path does the same with a `save` error. `ConvertController::convert` returns a structured `{"error": ...}` body instead of a 500 response, and while there it also gains the `parent::__construct` call it was missing (the controller never called it, so `$this->request` was null, a separate pre-existing bug).

One deliberate inconsistency: the error code depends on who is listening. The socket replies go to the editor, which runs `data` through `c_oAscError.ID`, so they use `-4` (`DownloadError`). `ConvertController` answers the connector over the server-side conversion API, which is a different code space, so it uses `-3` (conversion) and `-5` (password).

## A note on scope

This is against `master`, so `ConverterBinary::run` still has its `string $param, string $password = null` signature with the implicit-nullable PHP 8.4 deprecation. I left that alone to keep the change to one thing; #376 handles it.

## Testing

Nextcloud 33, PHP 8.4, local appdata. Before the fix a real `.docx` hung on "Loading document" with the `NotFoundException` in the log. After it, a fresh reconversion renders, and the file cache holds `Editor.bin` and `media/image*.png` (which is the proof the scan needs to be recursive: a shallow one would leave those four images out). `php -l` passes on all four files.

