### PR TITLE
Fix co-authoring not showing other users' changes live

### DIFF
--- a/lib/XHRCommand/SaveChangesCommand.php
+++ b/lib/XHRCommand/SaveChangesCommand.php
@@ -46,10 +46,29 @@ class SaveChangesCommand implements ICommandHandler {
 		return 'saveChanges';
 	}
 
+	/**
+	 * A save may arrive split over several messages: sdkjs slices its change
+	 * array into chunks of at most websocketMaxPayloadSize (1.5 MB) and flags
+	 * the first and last one. Absent flags mean a single, complete message.
+	 */
+	private static function isFirstChunk(array $command): bool {
+		return !isset($command['startSaveChanges']) || (bool)$command['startSaveChanges'];
+	}
+
+	private static function isLastChunk(array $command): bool {
+		return !isset($command['endSaveChanges']) || (bool)$command['endSaveChanges'];
+	}
+
 	public function handle(array $command, Session $session, IIPCChannel $sessionChannel, IIPCChannel $documentChannel, CommandDispatcher $commandDispatcher): void {
 		$changes = json_decode($command['changes']);
 
-		if ($command['deleteIndex']) {
+		$isFirstChunk = self::isFirstChunk($command);
+		$isLastChunk = self::isLastChunk($command);
+
+		// deleteIndex is repeated on every chunk of the same save, and it is
+		// relative to the change store as it was before the save started, so
+		// re-applying it once we have stored a chunk would delete that chunk.
+		if ($isFirstChunk && $command['deleteIndex']) {
 			$this->changeStore->deleteChangesByIndex($session->getDocumentId(), (int)$command['deleteIndex']);
 		}
 
@@ -58,7 +77,6 @@ class SaveChangesCommand implements ICommandHandler {
 		$this->changeStore->addChangesForDocument($session->getDocumentId(), $changes, $session->getUserId(), $session->getUserOriginal());
 
 		$changeIndex = $this->changeStore->getMaxChangeIndexForDocument($session->getDocumentId());
-		;
 
 		$documentChannel->pushMessage(json_encode([
 			'type' => 'saveChanges',
@@ -71,8 +89,27 @@ class SaveChangesCommand implements ICommandHandler {
 			'startIndex' => $startIndex,
 			'changesIndex' => $changeIndex,
 			'locks' => [],
-			'excelAdditionalInfo' => '{}',
+			// Relayed, not synthesised: for spreadsheets this carries the
+			// recalcIndexRows/recalcIndexColumns the receiver needs to shift
+			// other users' locks after a row or column insert, and for text
+			// documents it carries the sender's cursor position, which is how
+			// foreign cursors move during fast co-editing.
+			'excelAdditionalInfo' => $command['excelAdditionalInfo'] ?? null,
+			// Both flags have to be relayed: the receiving sdkjs buffers the
+			// changes of every message whose endSaveChanges is not true and
+			// only applies the batch once it sees the closing one. Sending the
+			// broadcast without them means every remote change is buffered
+			// forever, so nothing a co-author types ever appears.
+			'startSaveChanges' => $isFirstChunk,
+			'endSaveChanges' => $isLastChunk,
 		]));
+
+		if (!$isLastChunk) {
+			// Mid-save: the client waits for savePartChanges before sending the
+			// next chunk, and the locks stay held until the save completes.
+			$sessionChannel->pushMessage('{"type":"savePartChanges","changesIndex":' . $changeIndex . '}');
+			return;
+		}
 
 		if ($command["releaseLocks"]) {
 			$released = $this->lockStore->releaseLocks($session->getDocumentId(), $session->getUserId());


### PR DESCRIPTION
## What was broken

With two people in one document, neither saw the other's typing. The document
was never actually corrupted or lost — the change store had everything, and
`documentserver:flush` wrote a correct file with both users' edits — so the
problem only showed on screen, in the live session.

## Why

`SaveChangesCommand` broadcast remote changes without the `startSaveChanges` /
`endSaveChanges` flags that sdkjs sends with its own `saveChanges` command. A
save may arrive split into chunks of at most 1.5 MB (`websocketMaxPayloadSize`),
and the receiving client buffers every messageast
one — `DocsCoApi.prototype._onSaveChanges`:

```js
if (!data["endSaveChanges"]) {
  this._saveChangesChunks.push(data["changes"]
  return;
}

Without the flag every remote change was received, queued into
_saveChangesChunks, and never applied. The gato
this is not a 9.4.0 regression; it stayed hidden because what gets verified after
an upgrade is the saved file, not what each se

Two smaller relay gaps in the same handler:

- excelAdditionalInfo was hardcoded to '{}' instead of being relayed. For
  spreadsheets it carries the recalcIndexRows er
  needs to shift other users' locks after a row or column insert; for text
  documents it carries the sender's cursor posursors
  move during fast co-editing.
- A chunked save never got its savePartChangesting
  to send chunk 2 — and deleteIndex, which is repeated on every chunk and is
  relative to the store as it was before the save started, was re-applied per
  chunk, deleting the chunks already stored.

The fix

lib/XHRCommand/SaveChangesCommand.php:

- relay startSaveChanges / endSaveChanges on tan
  a single complete message, so both default to true);
- relay excelAdditionalInfo rather than synthesising it;
- reply savePartChanges and hold the locks on a non-final chunk, and apply
  deleteIndex only on the first one.

One file, no schema or protocol additions.

Testing

Local rig (Nextcloud 34.0.3 + onlyoffice connector 10.1.2 + ONLYOFFICE 9.4.0),
two headless browsers logged in as different uin
turn, then reading both document models back to check what each session actually
displays:

┌──────┬───────────────────────┬──────────────
│      │   live co-authoring   │ markers in th
├──────┼───────────────────────┼──────────────
│ docx │ pass (2 and 4 rounds) │ 4/4                                   │
├──────┼───────────────────────┼───────────────────────────────────────┤
│ xlsx │ pass                  │ 4/4
├──────┼───────────────────────┼───────────────────────────────────────┤
│ pptx │ pass                  │ 4/4                                   │
└──────┴───────────────────────┴──────────────

One socket session per browser throughout, so no reconnect churn;
bufferedChunks stays at 0 and lastOtherSaveTim

Reverting only this file reproduces the bug exs at
-1, bufferedChunks grows 1 → 2 as each remote save piles up unapplied, and
each user sees only their own text.

Also verified on the production instance with two live sessions.