### PR TITLE
Bundle Euro-Office instead of ONLYOFFICE DocumentServer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,19 @@ appstore_package_name=$(appstore_build_directory)/$(app_name)
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
 
-# ONLYOFFICE DocumentServer release to bundle. Override to test another one:
-#   make oo_version=v8.3.3 3rdparty/onlyoffice/documentserver
-oo_version=v9.4.0
+# Document server release to bundle. Euro-Office is a fork of ONLYOFFICE
+# DocumentServer and packages the same tree in the same shape, so one build
+# serves either; what differs is the vendor directory inside the package, which
+# the steps below locate instead of hardcoding. Override to test another
+# release, or to go back to upstream:
+#   make ds_version=v9.3.3 3rdparty/onlyoffice/documentserver
+#   make ds_repo=ONLYOFFICE/DocumentServer ds_version=v9.4.0 3rdparty/onlyoffice/documentserver
+#
+# The local directory keeps its name: it is part of the URLs sdkjs requests
+# (see appinfo/routes.php and JSSettingsHelper), so renaming it is its own
+# change.
+ds_repo=Euro-Office/DocumentServer
+ds_version=v9.3.4-hotfix.1
 oo_dir=$(CURDIR)/3rdparty/onlyoffice/documentserver
 
 all: 3rdparty/onlyoffice/documentserver version
@@ -37,10 +47,22 @@ appstore:
 3rdparty/onlyoffice/documentserver:
 	mkdir -p 3rdparty/onlyoffice
 	mkdir -p oo-extract
-	curl -sLO https://github.com/ONLYOFFICE/DocumentServer/releases/download/$(oo_version)/onlyoffice-documentserver.x86_64.rpm
-	cd oo-extract && rpm2cpio ../onlyoffice-documentserver.x86_64.rpm | cpio -idm
+	# Resolve the asset rather than composing its name: ONLYOFFICE publishes
+	# one fixed filename per release, while Euro-Office puts the version in the
+	# filename and it does not always match the tag (the v9.3.2 release ships a
+	# 9.3.1-dev.1 rpm).
+	url=$$(curl -sfL https://api.github.com/repos/$(ds_repo)/releases/tags/$(ds_version) \
+		| grep -o 'https://[^"]*x86_64[.]rpm' | head -1); \
+	if [ -z "$$url" ]; then echo "no x86_64 rpm asset for $(ds_repo) $(ds_version)" >&2; exit 1; fi; \
+	echo "fetching $$url"; \
+	curl -sL -o documentserver.x86_64.rpm "$$url"
+	cd oo-extract && rpm2cpio ../documentserver.x86_64.rpm | cpio -idm
 	chmod -R 777 oo-extract/
-	cp -r oo-extract/var/www/onlyoffice/documentserver 3rdparty/onlyoffice
+	# var/www/<vendor>/documentserver: "onlyoffice" upstream, "euro-office"
+	# on the fork.
+	src=$$(find oo-extract/var/www -mindepth 2 -maxdepth 2 -type d -name documentserver | head -1); \
+	if [ -z "$$src" ]; then echo 'no documentserver tree in the package' >&2; exit 1; fi; \
+	cp -r "$$src" 3rdparty/onlyoffice
 	# Up to 8.x the package kept the converter's shared libraries in
 	# /usr/lib64 and expected the distro to place them on the library path;
 	# since 9.x they ship inside FileConverter/bin instead, so only copy them
@@ -48,7 +70,7 @@ appstore:
 	bash -c 'if [ -d oo-extract/usr/lib64 ]; then \
 		cp oo-extract/usr/lib64/* 3rdparty/onlyoffice/documentserver/server/FileConverter/bin/; \
 		cp oo-extract/usr/lib64/* 3rdparty/onlyoffice/documentserver/server/tools/; fi'
-	rm -f onlyoffice-documentserver.x86_64.rpm
+	rm -f documentserver.x86_64.rpm
 	bash -c 'rm -rf 3rdparty/onlyoffice/documentserver/server/{Common/config/*,DocService,Metrics}'
 	# npm and Metrics belong to the Node DocService, which we replace with
 	# the PHP implementation and never ship, so they are dead weight.
@@ -59,7 +81,10 @@ appstore:
 	# and sr-Latn, leaving 200+ MB of screenshots nothing can request.
 	bash -c 'for d in 3rdparty/onlyoffice/documentserver/web-apps/apps/*/main/resources/help/*/images; do \
 		case "$$d" in */help/en/images) ;; *) rm -rf "$$d" ;; esac; done'
-	cp oo-extract/etc/onlyoffice/documentserver/default.json 3rdparty/onlyoffice/documentserver/server/Common/config/
+	# Same story as the tree above: etc/<vendor>/documentserver/default.json.
+	cfg=$$(find oo-extract/etc -mindepth 3 -maxdepth 3 -path '*/documentserver/default.json' | head -1); \
+	if [ -z "$$cfg" ]; then echo 'no default.json in the package' >&2; exit 1; fi; \
+	cp "$$cfg" 3rdparty/onlyoffice/documentserver/server/Common/config/
 	# Since 8.x the package ships web-apps api.js as an empty file plus an
 	# api.js.tpl that DocService normally renders at start-up. We do not ship
 	# DocService, so render it here. {{HASH_POSTFIX}} is left in place on

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,11 +2,13 @@
 <info>
 	<id>documentserver_community</id>
 	<name>Community Document Server</name>
-	<summary>Document server for OnlyOffice, community edition</summary>
+	<summary>Document server for OnlyOffice, community edition, running Euro-Office</summary>
 	<description><![CDATA[Document server for OnlyOffice, community edition.
 
 The community document server is designed to make it easy to get OnlyOffice running in a Nextcloud instance without the need to setup an external document server,
 the community document server does not support all features of the official OnlyOffice document server and does not provide the same performance and scalability.
+
+It bundles Euro-Office (https://github.com/Euro-Office/DocumentServer), a fork of ONLYOFFICE DocumentServer, and plugs into the OnlyOffice connector app as before.
 
 If you are setting up a larger instance or require the additional performance, please see https://onlyoffice.com for options for getting the official document server.
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,5 +21,14 @@ return [
 		['name' => 'Static#pluginsJSON', 'url' => '/plugins.json', 'verb' => 'GET'],
 		['name' => 'Static#pluginsJSON', 'url' => '/3rdparty/onlyoffice/documentserver/plugins.json', 'verb' => 'GET'],
 		['name' => 'Static#thirdparty', 'url' => '/3rdparty/onlyoffice/documentserver/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+']],
+
+		// Euro-Office's editor HTML pulls in sdkjs with a relative path written
+		// for a document server that owns the origin root
+		// ("../../../../../../sdkjs/common/device_scale.js"). Ours sits three
+		// directories deeper, so the browser runs out of parents and asks for
+		// /3rdparty/sdkjs/... instead. Keep this narrow: a catch-all
+		// /3rdparty/{path} is matched ahead of the specific route above and
+		// takes the whole static tree down with it.
+		['name' => 'Static#sdkjsRoot', 'url' => '/3rdparty/sdkjs/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+']],
 	]
 ];

--- a/lib/Controller/StaticController.php
+++ b/lib/Controller/StaticController.php
@@ -87,6 +87,22 @@ class StaticController extends Controller {
 		return $this->createFileResponse($localPath);
 	}
 
+	/**
+	 * sdkjs, reachable one directory prefix up.
+	 *
+	 * The editor HTML is written for a document server that owns the origin
+	 * root, so its script path for sdkjs walks up past ours - which lives
+	 * three directories deeper - and the browser gives up at
+	 * /3rdparty/sdkjs/... Serving the same files there costs nothing: they are
+	 * already public under the full prefix.
+	 */
+	#[NoCSRFRequired]
+	#[NoAdminRequired]
+	#[PublicPage]
+	public function sdkjsRoot(string $path) {
+		return $this->thirdparty('sdkjs/' . $path);
+	}
+
 	#[NoCSRFRequired]
 	#[NoAdminRequired]
 	#[PublicPage]

--- a/lib/OnlyOffice/WebVersion.php
+++ b/lib/OnlyOffice/WebVersion.php
@@ -30,6 +30,6 @@ class WebVersion {
 		if ($apiJS && preg_match("|DocsAPI\.DocEditor\.version\s*=\s*function\(\) *\{\n\s+return\s'(\d+\.\d+\.\d+)';\n\s+}|", $apiJS, $matches)) {
 			return $matches[1];
 		}
-		return '9.4.0';
+		return '9.3.4';
 	}
 }


### PR DESCRIPTION
Euro-Office (https://github.com/Euro-Office/DocumentServer) is a fork of ONLYOFFICE DocumentServer and packages the same tree in the same shape, so one build serves either. Default is now v9.3.4-hotfix.1; upstream still builds with
  make ds_repo=ONLYOFFICE/DocumentServer ds_version=v9.4.0 \
      3rdparty/onlyoffice/documentserver

Two packaging differences mean the recipe had to stop hardcoding names rather than just swap a URL:

- Euro-Office puts the version in the rpm filename and it does not always match the tag (the v9.3.2 release ships a 9.3.1-dev.1 rpm), so the asset is resolved through the GitHub releases API. ONLYOFFICE's single fixed filename resolves through the same code.
- Its vendor directories are var/www/euro-office/documentserver and etc/euro-office/documentserver/default.json, so both are located instead of assumed.

3rdparty/onlyoffice/documentserver keeps its name: it is part of the URLs sdkjs requests, so renaming it is its own change.

One runtime incompatibility: the editor HTML loads sdkjs/common/device_scale.js - a file upstream 9.4.0 does not have - with a relative path written for a document server that owns the origin root ("../../../../../../sdkjs/..."). Ours sits three directories deeper, so the browser runs out of parents and asks for /3rdparty/sdkjs/..., which 404'd on every document open. Static#sdkjsRoot serves that. It is deliberately narrow: a catch-all /3rdparty/{path} is matched ahead of the existing /3rdparty/onlyoffice/documentserver/{path} and 404s the whole static tree, and reusing the Static#thirdparty route name would have replaced that route rather than added to it.

Verified on the local rig, app-store-shaped build: docx, xlsx and pptx each open with zero JS exceptions and zero failed requests, live co-authoring passes for all three (one socket session per browser, every marker visible in both sessions), and every marker survives documentserver:flush into the saved file. Swapping back to upstream 9.4.0 still runs clean, so the routing change is vendor-neutral. The published archive comes to 483,043,830 bytes against the 524,288,000 app store cap, 39 MB spare where 9.4.0 left 9 MB.
