### PR TITLE
Make the editor's chat panel work

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -33,9 +33,11 @@ use OCA\DocumentServer\IPC\IIPCFactory;
 use OCA\DocumentServer\OnlyOffice\URLDecoder;
 use OCA\DocumentServer\OnlyOffice\WebVersion;
 use OCA\DocumentServer\XHRCommand\AuthCommand;
+use OCA\DocumentServer\XHRCommand\ChatMessage;
 use OCA\DocumentServer\XHRCommand\CommandDispatcher;
 use OCA\DocumentServer\XHRCommand\CursorCommand;
 use OCA\DocumentServer\XHRCommand\GetLock;
+use OCA\DocumentServer\XHRCommand\GetMessages;
 use OCA\DocumentServer\XHRCommand\IsSaveLock;
 use OCA\DocumentServer\XHRCommand\LockExpire;
 use OCA\DocumentServer\XHRCommand\OpenDocument;
@@ -61,6 +63,8 @@ class DocumentController extends Controller {
 		UnlockDocument::class,
 		CursorCommand::class,
 		OpenDocument::class,
+		ChatMessage::class,
+		GetMessages::class,
 	];
 
 	public const IDLE_HANDLERS = [

--- a/lib/Document/DocumentStore.php
+++ b/lib/Document/DocumentStore.php
@@ -39,6 +39,9 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 
 class DocumentStore {
+	private const CHAT_FILE = 'chat.json';
+	private const CHAT_HISTORY_LIMIT = 100;
+
 	private $appData;
 	private $documentConverter;
 	private $config;
@@ -256,6 +259,34 @@ class DocumentStore {
 		});
 
 		return '/convert.' . $targetFormat;
+	}
+
+	/**
+	 * The chat history of an open document.
+	 *
+	 * Kept in the document's own folder rather than a table: it is per-editing
+	 * session state with the same lifetime as the converted document, so
+	 * closeDocument() disposes of it along with everything else. Capped,
+	 * because nothing else would ever trim it.
+	 */
+	public function getChatMessages(int $documentId): array {
+		$docFolder = $this->getDocumentFolder($documentId);
+		try {
+			$messages = json_decode($docFolder->getFile(self::CHAT_FILE)->getContent(), true);
+		} catch (NotFoundException $e) {
+			return [];
+		}
+		return is_array($messages) ? $messages : [];
+	}
+
+	public function addChatMessage(int $documentId, array $message): void {
+		$docFolder = $this->getDocumentFolder($documentId);
+		$messages = $this->getChatMessages($documentId);
+		$messages[] = $message;
+		if (count($messages) > self::CHAT_HISTORY_LIMIT) {
+			$messages = array_slice($messages, -self::CHAT_HISTORY_LIMIT);
+		}
+		$docFolder->newFile(self::CHAT_FILE)->putContent(json_encode($messages));
 	}
 
 	public function stashDocumentUrl(int $documentId, string $url) {

--- a/lib/XHRCommand/ChatMessage.php
+++ b/lib/XHRCommand/ChatMessage.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DocumentServer\XHRCommand;
+
+use OCA\DocumentServer\Channel\Session;
+use OCA\DocumentServer\Document\DocumentStore;
+use OCA\DocumentServer\IPC\IIPCChannel;
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * One chat message from the editor's chat panel.
+ *
+ * The panel is on by default (the connector only sends
+ * customization.chat when an admin switches it off), and without a handler
+ * every message was dropped, so chat looked broken out of the box.
+ *
+ * The sender gets the message back too: the panel does not add what you type
+ * to its own list, it waits to be told, and the document channel deliberately
+ * skips the session it came from.
+ */
+class ChatMessage implements ICommandHandler {
+	/** Long enough for a chunk of a message to be stored while another arrives. */
+	private const LOCK_ATTEMPTS = 5;
+	private const LOCK_RETRY_US = 50 * 1000;
+
+	private $documentStore;
+	private $lockingProvider;
+	private $logger;
+
+	public function __construct(
+		DocumentStore $documentStore,
+		ILockingProvider $lockingProvider,
+		LoggerInterface $logger
+	) {
+		$this->documentStore = $documentStore;
+		$this->lockingProvider = $lockingProvider;
+		$this->logger = $logger;
+	}
+
+	public function getType(): string {
+		return 'message';
+	}
+
+	public function handle(array $command, Session $session, IIPCChannel $sessionChannel, IIPCChannel $documentChannel, CommandDispatcher $commandDispatcher): void {
+		if (!isset($command['message']) || !is_string($command['message'])) {
+			return;
+		}
+
+		$message = [
+			'user' => $session->getUserId(),
+			'useridoriginal' => $session->getUserOriginal(),
+			'username' => $session->getUserName(),
+			'message' => $command['message'],
+			'time' => time() * 1000,
+		];
+
+		// Appending is read-modify-write on one file, so it has to be
+		// serialised against the other participants. Delivery still happens if
+		// the history cannot be updated: losing a message from the backlog is
+		// better than losing it from the conversation.
+		$this->withHistoryLock($session->getDocumentId(), function () use ($session, $message) {
+			$this->documentStore->addChatMessage($session->getDocumentId(), $message);
+		});
+
+		$payload = json_encode([
+			'type' => 'message',
+			'messages' => [$message],
+		]);
+		$sessionChannel->pushMessage($payload);
+		$documentChannel->pushMessage($payload);
+	}
+
+	private function withHistoryLock(int $documentId, callable $work): void {
+		$lock = 'documentserver_chat_' . $documentId;
+
+		for ($attempt = 0; $attempt < self::LOCK_ATTEMPTS; $attempt++) {
+			try {
+				$this->lockingProvider->acquireLock($lock, ILockingProvider::LOCK_EXCLUSIVE);
+			} catch (LockedException $e) {
+				usleep(self::LOCK_RETRY_US);
+				continue;
+			}
+
+			try {
+				$work();
+			} catch (\Exception $e) {
+				$this->logger->warning('documentserver could not store a chat message for document {doc}: {error}', [
+					'doc' => $documentId,
+					'error' => $e->getMessage(),
+					'exception' => $e,
+				]);
+			} finally {
+				$this->lockingProvider->releaseLock($lock, ILockingProvider::LOCK_EXCLUSIVE);
+			}
+			return;
+		}
+
+		$this->logger->warning('documentserver gave up on the chat history lock for document {doc}', [
+			'doc' => $documentId,
+		]);
+	}
+}

--- a/lib/XHRCommand/GetMessages.php
+++ b/lib/XHRCommand/GetMessages.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DocumentServer\XHRCommand;
+
+use OCA\DocumentServer\Channel\Session;
+use OCA\DocumentServer\Document\DocumentStore;
+use OCA\DocumentServer\IPC\IIPCChannel;
+
+/**
+ * The chat backlog, which the editor asks for once when it opens a document.
+ *
+ * Answered even when empty: the panel resets its list from whatever arrives
+ * first, so a late joiner sees the conversation instead of starting blank.
+ */
+class GetMessages implements ICommandHandler {
+	private $documentStore;
+
+	public function __construct(DocumentStore $documentStore) {
+		$this->documentStore = $documentStore;
+	}
+
+	public function getType(): string {
+		return 'getMessages';
+	}
+
+	public function handle(array $command, Session $session, IIPCChannel $sessionChannel, IIPCChannel $documentChannel, CommandDispatcher $commandDispatcher): void {
+		$messages = $this->documentStore->getChatMessages($session->getDocumentId());
+		if (!$messages) {
+			return;
+		}
+
+		$sessionChannel->pushMessage(json_encode([
+			'type' => 'message',
+			'messages' => $messages,
+		]));
+	}
+}


### PR DESCRIPTION
sdkjs sends getMessages when the editor opens and message when someone types in the chat panel. Both were dropped, so the panel accepted text and swallowed it. And since the connector only emits customization.chat when an admin switches chat *off*, this was broken out of the box rather than only for instances that turned it on.

Two things worth knowing here. The sender is sent its own message back: the panel does not add what you type to its own list, it waits to be told, and IPCMulticast deliberately skips the session a message came from - so the handler pushes to both the session and the document channel. And the history lives in chat.json inside the document's appdata folder, following the stashDocumentUrl precedent: per-editing-session state with the same lifetime as the converted document, so closeDocument() disposes of it and no migration or schema change is needed. Appending is read-modify-write on one file, so it is serialised with a documentserver_chat_<id> lock, separate from the save lock so a flush does not block chat; if the lock cannot be had the message is still delivered and only the backlog entry is lost.

Only the client's setMode() asks for the backlog, once at init, so there is no reconnect path that would duplicate it in the panel.

Verified on the rig for docx, xlsx and pptx: each of two sessions sees both its own message and the other's with the right usernames, the backlog is complete on re-request, and a third session opening after the conversation finds all of it in the collection its panel renders from. The history file is gone after a flush once the sessions have expired.

