### PR TITLE
Declare and populate Change::$changeIndex

### DIFF
--- a/lib/Document/Change.php
+++ b/lib/Document/Change.php
@@ -29,13 +29,15 @@ class Change {
 	private $change;
 	private $user;
 	private $userOriginal;
+	private $changeIndex;
 
-	public function __construct(int $documentId, int $time, string $change, string $user, string $userOriginal) {
+	public function __construct(int $documentId, int $time, string $change, string $user, string $userOriginal, int $changeIndex) {
 		$this->documentId = $documentId;
 		$this->time = $time;
 		$this->change = $change;
 		$this->user = $user;
 		$this->userOriginal = $userOriginal;
+		$this->changeIndex = $changeIndex;
 	}
 
 	public function getDocumentId(): int {
@@ -78,7 +80,8 @@ class Change {
 			(int)$row['time'],
 			$row['change'],
 			$row['user'],
-			$row['user_original']
+			$row['user_original'],
+			(int)$row['change_index']
 		);
 	}
 }

--- a/lib/XHRCommand/SaveChangesCommand.php
+++ b/lib/XHRCommand/SaveChangesCommand.php
@@ -82,10 +82,11 @@ class SaveChangesCommand implements ICommandHandler {
 			'type' => 'saveChanges',
 			'docId' => $session->getDocumentId(),
 			'userId' => $session->getUserId(),
-			'changes' => array_map(function (string $changeString) use ($session) {
-				$change = new Change($session->getDocumentId(), time(), $changeString, $session->getUserId(), $session->getUserOriginal());
+			'changes' => array_map(function (string $changeString, int $offset) use ($session, $startIndex) {
+				// the store numbers the changes it just stored from $startIndex + 1 up
+				$change = new Change($session->getDocumentId(), time(), $changeString, $session->getUserId(), $session->getUserOriginal(), $startIndex + 1 + $offset);
 				return $change->formatForClient();
-			}, $changes),
+			}, $changes, array_keys($changes)),
 			'startIndex' => $startIndex,
 			'changesIndex' => $changeIndex,
 			'locks' => [],


### PR DESCRIPTION
Addresses finding 2 of #380.

`Change::getChangeIndex()` returned `$this->changeIndex`, a property the class never declared and nothing ever set. Any call returned `null` from an `int`-typed method — a `TypeError` — plus a dynamic-property deprecation on PHP 8.4+.

The issue offers deleting the getter as the smaller change. I went the other way, because both `getChangesForDocument()` and `getChangesAndMarkProcessingForDocument()` already select `change_index`: the plumbing was there and only the model was missing. So the property is declared and taken through the constructor, `fromRow()` fills it from the column it was already reading, and the one other construction site — the co-authoring broadcast in `SaveChangesCommand` — passes the index the store assigns.

Making the parameter required rather than defaulted keeps the class from quietly reporting `0` for an index it does not know. `Change` is app-internal, so there is no API to break.

### Verified

On a local Nextcloud 34 rig, storing three changes and reading them back:

- before: `TypeError: Change::getChangeIndex(): Return value must be of type int, null returned`, on every row
- after: `0`, `1`, `2`

Live co-authoring (two sessions, docx and xlsx) still passes, with every marker visible in both sessions and present in the file after `documentserver:flush`.

### Merging

No file overlap with the other four #380 PRs. One thing to know if #380 (3) also lands (see that PR): with the retry in place, the index this PR computes as `startIndex + 1 + offset` is right except after a collision, when the batch lands further along. Nothing reads that field today, so it is latent either way — `chadek:fix/380-all` carries a follow-up commit that has `addChangesForDocument()` return the index it actually assigned. Worth applying once both are in.