### PR TITLE
Retry a change batch that collides on change_index

### DIFF
--- a/lib/Document/ChangeStore.php
+++ b/lib/Document/ChangeStore.php
@@ -25,9 +25,27 @@ namespace OCA\DocumentServer\Document;
 
 use OCA\DocumentServer\DB\QueryHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\Exception as DBException;
 use OCP\IDBConnection;
 
 class ChangeStore {
+	/**
+	 * How often a batch of changes is re-tried when another editor took the
+	 * change indexes it was aiming for. Every attempt after the first works
+	 * from a max that already includes the other writer's changes, so a
+	 * handful covers far more concurrent savers than a document ever has;
+	 * the bound is only there so a genuinely broken insert cannot loop.
+	 */
+	private const MAX_INSERT_ATTEMPTS = 10;
+
+	/**
+	 * Upper bound, in microseconds, of the wait before a retry. Writers that
+	 * collided are in lockstep by definition, so retrying them all immediately
+	 * just reproduces the collision; the wait is randomised to break that up
+	 * and grows with the attempt count.
+	 */
+	private const RETRY_BACKOFF_USEC = 5000;
+
 	private $connection;
 	private $timeFactory;
 
@@ -39,18 +57,47 @@ class ChangeStore {
 		$this->timeFactory = $timeFactory;
 	}
 
+	/**
+	 * Two editors saving at the same moment used to read the same max change
+	 * index and aim for the same slots. (document_id, change_index) is unique,
+	 * so the loser did not corrupt the change log - it got a constraint
+	 * violation out of an unclosed transaction, which surfaced as a failed
+	 * save. Read the max inside the transaction and retry the batch when it
+	 * collides: by then the other writer has committed, so the fresh max is
+	 * past its changes.
+	 *
+	 * @throws DBException
+	 */
 	public function addChangesForDocument(int $documentId, array $changes, string $user, string $userOriginal) {
 		$time = $this->timeFactory->getTime();
-		$changeIndex = $this->getMaxChangeIndexForDocument($documentId) + 1;
 
-		$this->connection->beginTransaction();
+		for ($attempt = 1;; $attempt++) {
+			$this->connection->beginTransaction();
 
-		foreach ($changes as $change) {
-			$this->addChangeForDocument($documentId, $change, $user, $userOriginal, $time, $changeIndex);
-			$changeIndex++;
+			try {
+				$changeIndex = $this->getMaxChangeIndexForDocument($documentId) + 1;
+
+				foreach ($changes as $change) {
+					$this->addChangeForDocument($documentId, $change, $user, $userOriginal, $time, $changeIndex);
+					$changeIndex++;
+				}
+
+				$this->connection->commit();
+				return;
+			} catch (\Throwable $e) {
+				if ($this->connection->inTransaction()) {
+					$this->connection->rollBack();
+				}
+
+				$isCollision = $e instanceof DBException
+					&& $e->getReason() === DBException::REASON_UNIQUE_CONSTRAINT_VIOLATION;
+				if (!$isCollision || $attempt >= self::MAX_INSERT_ATTEMPTS) {
+					throw $e;
+				}
+
+				usleep(random_int(0, self::RETRY_BACKOFF_USEC * $attempt));
+			}
 		}
-
-		$this->connection->commit();
 	}
 
 	private function addChangeForDocument(int $documentId, string $change, string $user, string $userOriginal, int $time, int $changeIndex) {


### PR DESCRIPTION
Addresses finding 3 of #380 — with a correction to the diagnosis, which changes what the fix needs to be.

The issue proposes adding a unique index on `(document_id, change_index)` plus a retry. **That index already exists**, added by `Version001000Date20200107143228` as `documentserver_change_doc_id`. So no migration is needed, and colliding writers never actually produced duplicate indexes — the invariant held.

What happens instead is worse than duplicates. `addChangesForDocument()` calls `beginTransaction()` and has no `catch`, so the constraint violation is thrown out of a transaction nobody closes. The connection is then stuck inside a dead transaction and **every later query in the same request** fails with `SAVEPOINT DOCTRINE_n does not exist`. One collision doesn't just fail the save that raced; it fails that session's saves from then on.

The fix is therefore the retry alone: read the max inside the transaction, roll back on failure, and retry on a unique-constraint violation. The backoff is not decoration — writers that collided are in lockstep by definition, and retrying them all immediately just reproduces the collision. Without jitter the stress run still lost 5 batches in 60; with it, none.

`SELECT ... FOR UPDATE` was the other option in the issue. I did not take it: `IQueryBuilder` has no portable row-locking, and it would not work on SQLite. The retry is portable across all three supported databases.

### Verified

On a local Nextcloud 34 rig (MariaDB 11.8, READ-COMMITTED), N processes writing change batches to one document in a tight loop:

| load | before | after |
|---|---|---|
| 4 writers × 15 batches | 38 of 120 changes stored, 41 of 60 batches failed | 120 of 120, 0 failures (4 consecutive runs) |
| 6 writers × 20 batches, sub-3ms gaps | — | ~238-240 of 240; retries exhaust roughly once in 240 batches |
| 3 writers, ~100ms apart | — | 72 of 72, 0 failures |

No duplicate indexes and no gaps in any run. The remaining exhaustions at six tight-loop writers are far past anything real co-authoring does, and they now fail cleanly with the transaction rolled back rather than poisoning the connection.

Live co-authoring (two sessions on a spreadsheet, two rounds) passes, with all four markers visible in both sessions and in the file after `documentserver:flush`.

### Merging

No file overlap with the other four #380 PRs. See the note in #380 (2)'s PR about the small follow-up worth applying once both are in.