### PR TITLE
Stop the memcache IPC backend losing an in-flight message

### DIFF
--- a/lib/IPC/MemcacheIPCBackend.php
+++ b/lib/IPC/MemcacheIPCBackend.php
@@ -30,6 +30,15 @@ use OCP\IMemcache;
  * IPC Channels built on top of memcache concurrency primitives
  */
 class MemcacheIPCBackend implements IIPCBackend {
+	/**
+	 * How many consecutive pops may find a claimed slot still empty before the
+	 * slot is written off. A push claims its slot and writes the payload one
+	 * statement later, so a real message lands within a poll or two; the bound
+	 * only exists so that a writer which died in between cannot block the
+	 * channel for good. Channel::getResponse() polls every 100ms.
+	 */
+	private const MAX_PUBLISH_MISSES = 50;
+
 	private $memcache;
 
 	public function __construct(IMemcache $memcache) {
@@ -46,25 +55,53 @@ class MemcacheIPCBackend implements IIPCBackend {
 		$this->memcache->remove("$channel::read_key");
 	}
 
+	/**
+	 * Claiming the slot with an atomic inc is what stops two concurrent pushes
+	 * from writing the same key, so the payload can only be written afterwards.
+	 * That leaves a window in which the slot exists but the message does not,
+	 * which popMessage() has to cope with.
+	 */
 	public function pushMessage(string $channel, string $message) {
 		$key = $this->memcache->inc("$channel::write_key");
 		$this->memcache->set("$channel::message_$key", $message, Channel::TIMEOUT * 4);
 	}
 
 	public function popMessage(string $channel, int $timeout): ?string {
-		$writeKey = $this->memcache->get("$channel::write_key");
-		$readKey = $this->memcache->inc("$channel::read_key");
+		$writeKey = (int)$this->memcache->get("$channel::write_key");
+		$readKey = (int)$this->memcache->get("$channel::read_key") + 1;
 
-		if ($writeKey >= $readKey) {
-			$message = $this->memcache->get("$channel::message_$readKey");
-			$this->memcache->remove("$channel::message_$readKey");
-			return $message;
-		} else {
-			// no unread message, return read pointer
+		if ($writeKey < $readKey) {
+			// no unread message
+			return null;
+		}
 
-			$this->memcache->dec("$channel::read_key");
+		// The read pointer only moves once the message is in hand. Claiming the
+		// slot first - as incrementing read_key up front did - consumed the slot
+		// of a push that had not written its payload yet, and that message was
+		// then gone for good.
+		$message = $this->memcache->get("$channel::message_$readKey");
+
+		if ($message === null || !$this->memcache->cad("$channel::message_$readKey", $message)) {
+			// Either the push has not written its payload yet, or another reader
+			// on this channel took the message between the two calls. Both are
+			// resolved by leaving the pointer alone and letting the next poll
+			// have another go. A slot that stays empty for longer than any push
+			// can take is written off, so a writer that died mid-publish does
+			// not stall the channel.
+			$misses = $this->memcache->inc("$channel::miss_$readKey");
+			if (is_int($misses) && $misses < self::MAX_PUBLISH_MISSES) {
+				return null;
+			}
+
+			$this->memcache->remove("$channel::miss_$readKey");
+			$this->memcache->inc("$channel::read_key");
 
 			return null;
 		}
+
+		$this->memcache->remove("$channel::miss_$readKey");
+		$this->memcache->inc("$channel::read_key");
+
+		return $message;
 	}
 }

--- a/tests/IPC/MemcacheIPCBackendTest.php
+++ b/tests/IPC/MemcacheIPCBackendTest.php
@@ -38,4 +38,60 @@ class MemcacheIPCBackendTest extends BackendTest {
 	protected function getBackend(): IIPCBackend {
 		return new MemcacheIPCBackend($this->cache);
 	}
+
+	/**
+	 * pushMessage() claims its slot with an atomic inc and writes the payload
+	 * one statement later, so a pop can land in between. It must not consume
+	 * the slot there: the message is on its way.
+	 */
+	public function testPopDuringInFlightPush() {
+		$backend = $this->getBackend();
+
+		// a writer that has claimed slot 1 but not yet written its payload
+		$this->cache->inc("ch1::write_key");
+
+		$this->assertEquals(null, $backend->popMessage("ch1", 1));
+
+		// the writer finishes
+		$this->cache->set("ch1::message_1", "in-flight", 100);
+
+		$this->assertEquals("in-flight", $backend->popMessage("ch1", 1));
+	}
+
+	/**
+	 * A message queued behind an in-flight one must not overtake it either.
+	 */
+	public function testInFlightPushKeepsOrder() {
+		$backend = $this->getBackend();
+
+		$this->cache->inc("ch1::write_key");
+		$backend->pushMessage("ch1", "second");
+
+		$this->assertEquals(null, $backend->popMessage("ch1", 1));
+
+		$this->cache->set("ch1::message_1", "first", 100);
+
+		$this->assertEquals("first", $backend->popMessage("ch1", 1));
+		$this->assertEquals("second", $backend->popMessage("ch1", 1));
+		$this->assertEquals(null, $backend->popMessage("ch1", 1));
+	}
+
+	/**
+	 * Holding the pointer back must not turn into a wedged channel when the
+	 * payload never arrives at all, e.g. a writer that died between claiming
+	 * the slot and writing to it.
+	 */
+	public function testSlotThatNeverGetsItsPayloadIsGivenUpOn() {
+		$backend = $this->getBackend();
+
+		$this->cache->inc("ch1::write_key");
+		$backend->pushMessage("ch1", "after the dead slot");
+
+		$message = null;
+		for ($i = 0; $i < 500 && $message === null; $i++) {
+			$message = $backend->popMessage("ch1", 1);
+		}
+
+		$this->assertEquals("after the dead slot", $message);
+	}
 }


### PR DESCRIPTION
Addresses finding 4 of #380.

`pushMessage()` claims its slot with an atomic `inc` on `write_key` and writes the payload one statement later. It has to: the `inc` is what stops two writers picking the same slot. `popMessage()` claimed the read slot the same way, so a pop landing in that window saw `write_key >= read_key`, read a message that was not there yet, and returned `null` having consumed the slot. The message was then unreachable for good, and anything queued behind it moved up a place.

The issue is right that the publish cannot simply be reordered. But the race closes just as well from the read side, without needing a new atomic primitive: have the reader look before it commits. Read the payload, take it with compare-and-delete, and advance `read_key` only then. A pop in the publish window now leaves the pointer alone, and the next poll — 100ms later, per `Channel::getResponse()` — collects the message in its proper order. Compare-and-delete also keeps two readers on one channel from both claiming the same message, which the old atomic `inc` gave for free and a naive fix would lose.

Holding the pointer back does introduce a way to wedge the channel that did not exist before: a slot whose payload never arrives at all, e.g. a writer killed between claiming and writing. So a slot is written off after 50 consecutive misses — the old behaviour, delayed by about five seconds.

Redis and database backends take separate code paths and are untouched, as the issue notes.

### Verified

Three regression tests added to `tests/IPC/MemcacheIPCBackendTest.php`. Run against `ArrayCache`:

| | before | after |
|---|---|---|
| pop during an in-flight push | slot consumed, message lost forever | `null`, then the message on the next poll |
| a message queued behind an in-flight one | `second` overtakes `first`, `first` lost | `first` then `second` |
| slot whose payload never arrives | recovered after 2 polls | recovered after 51 polls |

All existing `BackendTest` assertions still pass, for this backend and for the database backend as a control.

Since the rig picks `DatabaseIPCBackend` by default (`MemcacheIPCFactory::isAvailable()` needs a *distributed* cache), I set `memcache.distributed` so live editing really went through this backend, then ran two sessions over three rounds on a document: all six markers visible in both sessions, one socket session per browser, and all six in the file after `documentserver:flush`.

### Merging

Independent of the other four #380 PRs — no shared files, any order.