### PR TITLE
Resolve command handlers through the app container

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -52,6 +52,7 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 class DocumentController extends Controller {
@@ -81,6 +82,7 @@ class DocumentController extends Controller {
 	private $ipcFactory;
 	private $sessionManager;
 	private LoggerInterface $logger;
+	private ContainerInterface $container;
 
 	public function __construct(
 		$appName,
@@ -92,7 +94,8 @@ class DocumentController extends Controller {
 		WebVersion $webVersion,
 		IIPCFactory $ipcFactory,
 		SessionManager $sessionManager,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		ContainerInterface $container
 	) {
 		parent::__construct($appName, $request);
 
@@ -104,15 +107,16 @@ class DocumentController extends Controller {
 		$this->ipcFactory = $ipcFactory;
 		$this->sessionManager = $sessionManager;
 		$this->logger = $logger;
+		$this->container = $container;
 	}
 
 	private function getCommandDispatcher(): CommandDispatcher {
 		$dispatcher = new CommandDispatcher();
 		foreach (self::COMMAND_HANDLERS as $class) {
-			$dispatcher->addHandler(\OC::$server->query($class));
+			$dispatcher->addHandler($this->container->get($class));
 		}
 		foreach (self::IDLE_HANDLERS as $class) {
-			$dispatcher->addIdleHandler(\OC::$server->query($class));
+			$dispatcher->addIdleHandler($this->container->get($class));
 		}
 		return $dispatcher;
 	}


### PR DESCRIPTION
Addresses finding 5 of #380.

`getCommandDispatcher()` pulled every command and idle handler out of `\OC::$server->query()`, the deprecated service locator. The PSR container the controller is already built from is injected instead; it resolves the same classes and falls back to the server container for their dependencies.

This is the minimal swap the issue suggests. Constructor-injecting the eleven handlers directly would be cleaner still, but they are instantiated per request behind a `const` list and that is a larger change than this finding calls for.

### Verified

On a local Nextcloud 34 rig — every socket command goes through this dispatcher, so any resolution failure shows up immediately:

- docx open → type → autosave: zero JS exceptions, zero failed requests, no errors in the app log, and the typed text present in the file after `documentserver:flush`
- live co-authoring, two sessions over two rounds: all four markers visible in both sessions, one socket session per browser, no mid-edit reconnects

### Merging

Independent of the other four #380 PRs — no shared files, any order.