### PR TITLE
Drop the database indexes that duplicate a wider one

### DIFF
--- a/lib/Migration/Version001500Date20260905101500.php
+++ b/lib/Migration/Version001500Date20260905101500.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\DocumentServer\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Drop the indexes that are fully covered by another index on the same table.
+ *
+ * Every dropped index is a left-prefix of a wider one, so lookups keep the same
+ * index while writes no longer have to maintain a second copy of it.
+ */
+class Version001500Date20260905101500 extends SimpleMigrationStep {
+	/** table name => the redundant index on it */
+	private const REDUNDANT_INDEXES = [
+		// left-prefix of documentserver_change_proc (document_id, processing)
+		'documentserver_changes' => 'documentserver_change_document',
+		// left-prefix of documentserver_ses_doc_last (document_id, last_seen)
+		'documentserver_sess' => 'documentserver_ses_doc',
+		// left-prefix of documentserver_locks_doc_user (document_id, user)
+		'documentserver_locks' => 'documentserver_locks_document',
+	];
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var Schema $schema */
+		$schema = $schemaClosure();
+		$changed = false;
+
+		foreach (self::REDUNDANT_INDEXES as $tableName => $indexName) {
+			if (!$schema->hasTable($tableName)) {
+				continue;
+			}
+
+			$table = $schema->getTable($tableName);
+			if ($table->hasIndex($indexName)) {
+				$table->dropIndex($indexName);
+				$changed = true;
+			}
+		}
+
+		// MySQL and MariaDB append the clustered primary key to every secondary index,
+		// so (session_id, message_id) is stored exactly like (session_id) there
+		if ($schema->hasTable('documentserver_ipc')) {
+			$table = $schema->getTable('documentserver_ipc');
+			if ($table->hasIndex('documentserver_ipc_session')
+				&& $table->getIndex('documentserver_ipc_session')->getColumns() !== ['session_id']) {
+				$table->dropIndex('documentserver_ipc_session');
+				$table->addIndex(['session_id'], 'documentserver_ipc_session');
+				$changed = true;
+			}
+		}
+
+		return $changed ? $schema : null;
+	}
+}


### PR DESCRIPTION
Fixes #353

`pt-duplicate-key-checker` flagged four overlapping indexes on the app's tables. Three of them are a left-prefix of a wider index on the same table, so every lookup they served is already served by the wider index while writes have to maintain both:

| dropped | covered by |
| --- | --- |
| `documentserver_change_document` (`document_id`) | `documentserver_change_proc` (`document_id`, `processing`) |
| `documentserver_ses_doc` (`document_id`) | `documentserver_ses_doc_last` (`document_id`, `last_seen`) |
| `documentserver_locks_document` (`document_id`) | `documentserver_locks_doc_user` (`document_id`, `user`) |

The fourth, `documentserver_ipc_session` (`session_id`, `message_id`), ends with the primary key of `documentserver_ipc`, which MySQL and MariaDB append to every secondary index anyway, so it is shortened to `(session_id)`.

I checked every query site first: all the `WHERE document_id = ?` lookups in `ChangeStore`, `SessionManager` and `LockStore` are served by the composite index's left prefix, and `DatabaseIPCBackend::popMessage` (`WHERE session_id = ? ORDER BY message_id ASC LIMIT 1`) is the only reader of the IPC index.

### Two notes

* **Migration ordering.** Nextcloud sorts migrations by the integer before `Date`, not by the app version. This app's migrations are `001000`/`001400` (from when it was version 1.4) while `info.xml` is on 0.3.x, so a `Version000303Date…` name would sort *first* and run before the tables exist — silently no-op on a fresh install and leaving fresh and upgraded installs with different schemas. Hence the `001500` prefix.
* **The IPC index is only truly redundant on MySQL/MariaDB.** On PostgreSQL the shortened index loses the ordered `message_id`, but a channel holds a handful of short-lived rows, so the extra write cost isn't worth it. This is noted in the code.

This migration only runs once `<version>` in `appinfo/info.xml` increases, which is a separate release commit here, so I left the version alone. Worth checking though: the `v0.3.3` tag still carries `0.3.2` inside `info.xml`, so the next release needs to land on ≥ 0.3.3 for this to fire on existing installs.

### Testing

Verified on a local Nextcloud 34.0.3 + MariaDB 11.8 rig with the app bind-mounted:

- **Upgrade path** (`occ upgrade` after a version bump) — all four indexes end up exactly as the issue asks.
- **Re-running the migration** — no-op; `changeSchema()` returns `null` when nothing differs.
- **Fresh install** (tables dropped, migration rows cleared, `app:enable`) — identical final schema to the upgraded one.
- **Live co-authoring**, two browser sessions on one document, 3 rounds — both sessions see each other's text, one socket session each, no buffered chunks; all markers present in the saved `.docx` after `documentserver:flush`.
- **Single-user edit** after the fresh install — no JS exceptions, no failed requests, typed text saved.
