### PR TITLE
 Save documents while they are being edited, and when the last editor leaves (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@ If autoconfiguration fails for any reason, you may manually enter the url. Log i
 
 After community document server update and any related app (OnlyOffice app for example), you should clear your browser cache to get newer version running.
 
+## Saving documents
+
+Documents are written back to Nextcloud:
+
+- while they are being edited, at most once a minute;
+- as soon as the last person closes the document;
+- and by the background job, which catches anything the first two missed - a
+  browser that crashed, a server restarted mid-edit - so a working cron is still
+  worth having.
+
+The periodic write is what bounds how much can be lost when a browser or the
+server goes away. It costs one document assembly per interval per document being
+edited, however much is typed in between, and none at all while nobody is
+typing. To change the interval:
+
+    occ config:app:set documentserver_community autosave_interval --value=120
+
+`0` turns it off, leaving the document to be written when everybody has left.
+`occ documentserver:flush` writes out everything that is open, whether or not
+anybody is still editing it.
+
 ## Adding fonts
 
 You can add custom fonts to the document server using the following occ commands

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -13,6 +13,9 @@ return [
 		['name' => 'Document#upload', 'url' => '/3rdparty/onlyoffice/documentserver/upload/{docId}/{user}/{index}', 'verb' => 'POST'],
 		['name' => 'Document#download', 'url' => '/3rdparty/onlyoffice/documentserver/downloadas/{docId}', 'verb' => 'POST'],
 
+		// The editor page saying goodbye on its way out; see js/close-beacon.js.
+		['name' => 'Document#sessionClosed', 'url' => '/session-closed', 'verb' => 'POST'],
+
 		['name' => 'CoAuthoring#command', 'url' => '/coauthoring/CommandService.ashx', 'verb' => 'POST'],
 
 		['name' => 'Convert#convert', 'url' => '/converter', 'verb' => 'POST'],

--- a/js/close-beacon-host.js
+++ b/js/close-beacon-host.js
@@ -8,7 +8,13 @@
  * cancelled with it - the frame's own goodbye never leaves the browser. This
  * page is still there, and can send it.
  *
- * The session id is published here by the editor frame (close-beacon.js).
+ * The session id is published here by the editor frame (close-beacon.js), and
+ * the frame it came from is remembered while it is still attached: "the editor
+ * is gone" then means that frame having left the document, rather than no frame
+ * currently answering to the session id, which is also what a frame that is
+ * merely reloading looks like. The server disposes of a document on the
+ * strength of this message, so it must not be sent for an editor that is still
+ * there.
  */
 (function () {
 	'use strict';
@@ -16,68 +22,75 @@
 	// the id we have already said goodbye for, rather than a flag: a page can
 	// close one document and open another without ever reloading
 	var goodbyeSent = null;
+	var editorFrame = null;
+	var editorSessionId = null;
 
 	function sessionId() {
 		return window.__documentServerSessionId;
 	}
 
-	function send() {
-		if (!sessionId() || goodbyeSent === sessionId() ||
-			!window.__documentServerCloseUrl || !navigator.sendBeacon) {
+	function send(id) {
+		if (!id || goodbyeSent === id || !window.__documentServerCloseUrl ||
+			!navigator.sendBeacon) {
 			return;
 		}
-		goodbyeSent = sessionId();
+		goodbyeSent = id;
 		try {
 			navigator.sendBeacon(
-				window.__documentServerCloseUrl + '?sid=' + encodeURIComponent(sessionId())
+				window.__documentServerCloseUrl + '?sid=' + encodeURIComponent(id)
 			);
 		} catch (e) {
 			/* nothing to fall back to */
 		}
 	}
 
-	function editorStillThere() {
+	/** The frame that published the session id, while it is still attached. */
+	function findEditorFrame() {
+		var id = sessionId();
+		if (!id) {
+			return null;
+		}
 		var frames = document.getElementsByTagName('iframe');
 		for (var i = 0; i < frames.length; i++) {
 			try {
 				if (frames[i].contentWindow &&
-					frames[i].contentWindow.__documentServerSessionId === sessionId()) {
-					return true;
+					frames[i].contentWindow.__documentServerSessionId === id) {
+					return frames[i];
 				}
 			} catch (e) {
-				/* a frame we may not look into is not ours to judge */
+				/* a frame we may not look into is not ours */
 			}
 		}
-		return false;
+		return null;
 	}
+
+	function check() {
+		var found = findEditorFrame();
+		if (found) {
+			editorFrame = found;
+			editorSessionId = sessionId();
+			return;
+		}
+		// Only once the frame we were watching has actually left the document.
+		// A frame that is still attached but not answering is loading, or
+		// reloading, and will publish its id again.
+		if (editorFrame && !document.contains(editorFrame)) {
+			send(editorSessionId);
+			editorFrame = null;
+			editorSessionId = null;
+		}
+	}
+
+	setInterval(check, 2000);
 
 	window.addEventListener('pagehide', function (event) {
 		// a page going into the back/forward cache can come back, with its
 		// socket, so it has not left
 		if (!event.persisted) {
-			send();
+			send(sessionId());
 		}
 	});
-	window.addEventListener('unload', send);
-
-	if (typeof MutationObserver === 'function') {
-		new MutationObserver(function (records) {
-			for (var i = 0; i < records.length; i++) {
-				var removed = records[i].removedNodes;
-				for (var j = 0; j < removed.length; j++) {
-					var node = removed[j];
-					if (node.nodeType !== 1) {
-						continue;
-					}
-					if (node.tagName === 'IFRAME' ||
-						(node.querySelector && node.querySelector('iframe'))) {
-						if (sessionId() && !editorStillThere()) {
-							send();
-							return;
-						}
-					}
-				}
-			}
-		}).observe(document.documentElement, {childList: true, subtree: true});
-	}
+	window.addEventListener('unload', function () {
+		send(sessionId());
+	});
 })();

--- a/js/close-beacon-host.js
+++ b/js/close-beacon-host.js
@@ -1,0 +1,83 @@
+/**
+ * The host page's half of telling the server when the editor goes away.
+ *
+ * Appended to the api.js the integration loads, so it runs in the page that
+ * embeds the editor rather than in the editor's own frame. That matters for the
+ * way an editor is usually closed: DocsAPI's destroyEditor() takes the iframe
+ * out of the DOM, and a request started by a document that is being detached is
+ * cancelled with it - the frame's own goodbye never leaves the browser. This
+ * page is still there, and can send it.
+ *
+ * The session id is published here by the editor frame (close-beacon.js).
+ */
+(function () {
+	'use strict';
+
+	// the id we have already said goodbye for, rather than a flag: a page can
+	// close one document and open another without ever reloading
+	var goodbyeSent = null;
+
+	function sessionId() {
+		return window.__documentServerSessionId;
+	}
+
+	function send() {
+		if (!sessionId() || goodbyeSent === sessionId() ||
+			!window.__documentServerCloseUrl || !navigator.sendBeacon) {
+			return;
+		}
+		goodbyeSent = sessionId();
+		try {
+			navigator.sendBeacon(
+				window.__documentServerCloseUrl + '?sid=' + encodeURIComponent(sessionId())
+			);
+		} catch (e) {
+			/* nothing to fall back to */
+		}
+	}
+
+	function editorStillThere() {
+		var frames = document.getElementsByTagName('iframe');
+		for (var i = 0; i < frames.length; i++) {
+			try {
+				if (frames[i].contentWindow &&
+					frames[i].contentWindow.__documentServerSessionId === sessionId()) {
+					return true;
+				}
+			} catch (e) {
+				/* a frame we may not look into is not ours to judge */
+			}
+		}
+		return false;
+	}
+
+	window.addEventListener('pagehide', function (event) {
+		// a page going into the back/forward cache can come back, with its
+		// socket, so it has not left
+		if (!event.persisted) {
+			send();
+		}
+	});
+	window.addEventListener('unload', send);
+
+	if (typeof MutationObserver === 'function') {
+		new MutationObserver(function (records) {
+			for (var i = 0; i < records.length; i++) {
+				var removed = records[i].removedNodes;
+				for (var j = 0; j < removed.length; j++) {
+					var node = removed[j];
+					if (node.nodeType !== 1) {
+						continue;
+					}
+					if (node.tagName === 'IFRAME' ||
+						(node.querySelector && node.querySelector('iframe'))) {
+						if (sessionId() && !editorStillThere()) {
+							send();
+							return;
+						}
+					}
+				}
+			}
+		}).observe(document.documentElement, {childList: true, subtree: true});
+	}
+})();

--- a/js/close-beacon.js
+++ b/js/close-beacon.js
@@ -1,0 +1,79 @@
+/**
+ * The editor page's half of telling the server when the editor goes away.
+ *
+ * A real document server holds a WebSocket, so a browser leaving the page is a
+ * closed socket and the document gets written straight away. This one is driven
+ * by HTTP long polling: when the editor is closed the pending poll is simply
+ * dropped, and nothing on the server runs to notice. Until the Cleanup
+ * background job came round the document was not written at all, which is how
+ * closing a document could lose everything typed into it (#100).
+ *
+ * All this side does is know which session it is. The session id is the one in
+ * the polling urls, picked up as they go past rather than read out of sdkjs
+ * internals, and it is published to the page that hosts the editor, because
+ * that is the one that can still make a request when this frame is being taken
+ * out of the DOM (see close-beacon-host.js).
+ */
+(function () {
+	'use strict';
+
+	var sessionId = null;
+
+	function publish(id) {
+		sessionId = id;
+		window.__documentServerSessionId = id;
+		try {
+			// same origin whenever this server is the one serving the editor,
+			// which is the only case where the host page can help
+			window.parent.__documentServerSessionId = id;
+			window.parent.__documentServerCloseUrl = window.__documentServerCloseUrl;
+		} catch (e) {
+			/* another origin: the host page cannot see us, and we are on our own */
+		}
+	}
+
+	function noteUrl(url) {
+		if (typeof url !== 'string' || url.indexOf('EIO=') === -1) {
+			return;
+		}
+		var match = /[?&]sid=([^&#]+)/.exec(url);
+		if (match) {
+			publish(decodeURIComponent(match[1]));
+		}
+	}
+
+	var open = XMLHttpRequest.prototype.open;
+	XMLHttpRequest.prototype.open = function (method, url) {
+		try {
+			noteUrl(url);
+		} catch (e) {
+			/* never break the request over this */
+		}
+		return open.apply(this, arguments);
+	};
+
+	// A tab being closed while the editor is in it: this frame is unloading
+	// along with its parent, and a beacon from an unloading document is still
+	// sent. A frame taken out of the DOM is a different matter - the load is
+	// cancelled with the document - which is what the host page covers.
+	function sayGoodbye(event) {
+		if (event && event.persisted) {
+			// going into the back/forward cache, not leaving: the page can come
+			// back, and saying goodbye for it would end a session still editing
+			return;
+		}
+		if (!sessionId || !navigator.sendBeacon) {
+			return;
+		}
+		try {
+			navigator.sendBeacon(
+				window.__documentServerCloseUrl + '?sid=' + encodeURIComponent(sessionId)
+			);
+		} catch (e) {
+			/* the page is going away; there is nothing to fall back to */
+		}
+	}
+
+	window.addEventListener('pagehide', sayGoodbye);
+	window.addEventListener('unload', sayGoodbye);
+})();

--- a/lib/BackgroundJob/Cleanup.php
+++ b/lib/BackgroundJob/Cleanup.php
@@ -66,15 +66,24 @@ class Cleanup extends Job {
 
 		$documents = $this->documentStore->getOpenDocuments();
 		foreach ($documents as $documentId) {
-			if (!$this->sessionManager->isDocumentActive($documentId)) {
-				try {
+			try {
+				if ($this->sessionManager->isDocumentActive($documentId)) {
+					// Still being edited. Write the file out anyway - the
+					// editing session keeps its change list and its baseline,
+					// so this costs a converter run and nothing else, and it
+					// means work in progress survives the browser or the
+					// server going away (#100). A document nobody has typed
+					// into since the last write returns without running the
+					// converter at all.
+					$this->saveHandler->saveSnapshot($documentId);
+				} else {
 					$this->saveHandler->flushChanges($documentId);
-				} catch (\Exception $e) {
-					$this->logger->error(
-						'Error while applying changes for document ' . $documentId, 
-						['exception' => $e, 'app' => 'documentserver_community']
-					);
 				}
+			} catch (\Exception $e) {
+				$this->logger->error(
+					'Error while applying changes for document ' . $documentId,
+					['exception' => $e, 'app' => 'documentserver_community']
+				);
 			}
 		}
 	}

--- a/lib/Channel/Channel.php
+++ b/lib/Channel/Channel.php
@@ -35,6 +35,17 @@ class Channel {
 
 	public const TIMEOUT = 25;
 
+	/**
+	 * How often a session waiting on its long poll says it is still there.
+	 *
+	 * Without this a session is only marked as seen when a poll starts, so a
+	 * client that is very much present can be 25 seconds "unseen" against a 30
+	 * second expiry - and an expired session is taken for a departed one, which
+	 * now means the document is written out and closed under whoever is still
+	 * editing it.
+	 */
+	public const SEEN_INTERVAL = 5;
+
 	private $sessionId;
 	private $documentId;
 	private $sessionChannel;
@@ -76,10 +87,16 @@ class Channel {
 			return [self::TYPE_OPEN, null];
 		} else {
 			$start = time();
+			$lastSeen = $start;
 			while ((time() - $start) < self::TIMEOUT) {
 				$message = $this->sessionChannel->popMessage(self::TIMEOUT);
 				if ($message) {
 					return [self::TYPE_ARRAY, json_decode($message, true)];
+				}
+
+				if ((time() - $lastSeen) >= self::SEEN_INTERVAL) {
+					$this->sessionManager->markAsSeen($this->sessionId);
+					$lastSeen = time();
 				}
 
 				usleep(100 * 1000);

--- a/lib/Channel/SessionCloser.php
+++ b/lib/Channel/SessionCloser.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2026 Fabrice Meyer <meyer.fabrice@gmx.fr>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DocumentServer\Channel;
+
+use OCA\DocumentServer\Document\SaveHandler;
+use OCA\DocumentServer\IPC\IIPCFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * An editor that is gone: it said so itself, rather than being found out by a
+ * session that stopped polling.
+ *
+ * This is the moment the document can be written: until the last participant
+ * leaves it must not be, and once they have left there is nobody polling any
+ * more, so the write used to wait for whenever the Cleanup background job
+ * happened to run next. On an instance whose cron is slow, misconfigured or set
+ * to AJAX, that was the difference between a document being saved and a day's
+ * work sitting in a database table nobody looked at (#100).
+ */
+class SessionCloser {
+	private $sessionManager;
+	private $saveHandler;
+	private $ipcFactory;
+	private $logger;
+
+	public function __construct(
+		SessionManager $sessionManager,
+		SaveHandler $saveHandler,
+		IIPCFactory $ipcFactory,
+		LoggerInterface $logger
+	) {
+		$this->sessionManager = $sessionManager;
+		$this->saveHandler = $saveHandler;
+		$this->ipcFactory = $ipcFactory;
+		$this->logger = $logger;
+	}
+
+	public function sessionLeft(Session $session): void {
+		$documentId = $session->getDocumentId();
+
+		$this->sessionManager->removeSession($session->getSessionId());
+
+		$participants = $this->sessionManager->getSessionsForDocument($documentId);
+
+		if (count($participants)) {
+			// Tell the people still in the document that this one left, rather
+			// than leaving them with a ghost participant until the session
+			// would have expired.
+			$documentChannel = new IPCMulticast(
+				$this->ipcFactory,
+				$this->sessionManager,
+				$documentId,
+				$session->getSessionId()
+			);
+			$documentChannel->pushMessage(json_encode([
+				'type' => 'connectState',
+				'participantsTimestamp' => time() * 1000,
+				'participants' => array_map(function (Session $participant) {
+					return $participant->formatForClient();
+				}, $participants),
+				'waitAuth' => false,
+			]));
+			return;
+		}
+
+		// The last participant left, so write the document out here instead of
+		// leaving it to the background job. Assembling it takes long enough
+		// that the browser, which is on its way out of the page, may well drop
+		// the request first; finish the save anyway, since nothing else is
+		// going to.
+		ignore_user_abort(true);
+
+		try {
+			$this->saveHandler->flushChanges($documentId);
+		} catch (\Throwable $e) {
+			// The changes are still in the store and the document folder is
+			// still there, so the background job will try again. This must not
+			// escape: on the command path it would fail the command, and on the
+			// beacon path there is nobody left to see it.
+			$this->logger->error('documentserver failed to save document {doc} when the last editor left', [
+				'doc' => $documentId,
+				'exception' => $e,
+			]);
+		}
+	}
+}

--- a/lib/Channel/SessionCloser.php
+++ b/lib/Channel/SessionCloser.php
@@ -56,6 +56,23 @@ class SessionCloser {
 		$this->logger = $logger;
 	}
 
+	/**
+	 * A client that said it is done co-authoring, from a page that is still
+	 * open.
+	 *
+	 * sdkjs sends that whenever it drops the editor to view mode - a licence
+	 * verdict on the number of users in the document, rights taken away,
+	 * disconnectEveryone, a critical error - so it is not a departure, and
+	 * treating it as one wrote the document out and deleted its folder from
+	 * under a page that was still there. The session stops being a participant;
+	 * if it is in fact still polling, its next poll revives it.
+	 */
+	public function sessionStoppedCoAuthoring(Session $session): void {
+		$this->sessionManager->expireSession($session->getSessionId());
+
+		$this->announceParticipants($session);
+	}
+
 	public function sessionLeft(Session $session): void {
 		$documentId = $session->getDocumentId();
 
@@ -64,23 +81,7 @@ class SessionCloser {
 		$participants = $this->sessionManager->getSessionsForDocument($documentId);
 
 		if (count($participants)) {
-			// Tell the people still in the document that this one left, rather
-			// than leaving them with a ghost participant until the session
-			// would have expired.
-			$documentChannel = new IPCMulticast(
-				$this->ipcFactory,
-				$this->sessionManager,
-				$documentId,
-				$session->getSessionId()
-			);
-			$documentChannel->pushMessage(json_encode([
-				'type' => 'connectState',
-				'participantsTimestamp' => time() * 1000,
-				'participants' => array_map(function (Session $participant) {
-					return $participant->formatForClient();
-				}, $participants),
-				'waitAuth' => false,
-			]));
+			$this->announceParticipants($session);
 			return;
 		}
 
@@ -103,5 +104,39 @@ class SessionCloser {
 				'exception' => $e,
 			]);
 		}
+	}
+
+	/**
+	 * Tell whoever is left in the document who that is, so a session that has
+	 * gone does not linger in everyone's participant list until it would have
+	 * expired.
+	 */
+	private function announceParticipants(Session $session): void {
+		$documentId = $session->getDocumentId();
+		$participants = array_filter(
+			$this->sessionManager->getSessionsForDocument($documentId),
+			function (Session $participant) use ($session) {
+				return $participant->getSessionId() !== $session->getSessionId();
+			}
+		);
+
+		if (!count($participants)) {
+			return;
+		}
+
+		$documentChannel = new IPCMulticast(
+			$this->ipcFactory,
+			$this->sessionManager,
+			$documentId,
+			$session->getSessionId()
+		);
+		$documentChannel->pushMessage(json_encode([
+			'type' => 'connectState',
+			'participantsTimestamp' => time() * 1000,
+			'participants' => array_map(function (Session $participant) {
+				return $participant->formatForClient();
+			}, array_values($participants)),
+			'waitAuth' => false,
+		]));
 	}
 }

--- a/lib/Channel/SessionManager.php
+++ b/lib/Channel/SessionManager.php
@@ -141,6 +141,20 @@ class SessionManager {
 		return QueryHelper::fetchFirstColumn($query);
 	}
 
+	/**
+	 * Drop a single session, for a client that said it was leaving rather than
+	 * one that stopped polling.
+	 */
+	public function removeSession(string $sessionId): void {
+		$this->ipcFactory->cleanupChannel($sessionId);
+
+		$query = $this->connection->getQueryBuilder();
+
+		$query->delete('documentserver_sess')
+			->where($query->expr()->eq('session_id', $query->createNamedParameter($sessionId)));
+		QueryHelper::executeStatement($query);
+	}
+
 	public function cleanSessions(): int {
 		$expiredSessions = $this->getExpiredSessions();
 

--- a/lib/Channel/SessionManager.php
+++ b/lib/Channel/SessionManager.php
@@ -142,6 +142,23 @@ class SessionManager {
 	}
 
 	/**
+	 * Mark a session as expired without deleting it.
+	 *
+	 * For a client that said it is done co-authoring while its page is still
+	 * open: it stops being a participant, but if it turns out to still be
+	 * polling, its next poll marks it as seen and it simply carries on. Nothing
+	 * is disposed of on the strength of a message a live page can send.
+	 */
+	public function expireSession(string $sessionId): void {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->update('documentserver_sess')
+			->set('last_seen', $query->createNamedParameter(0, \PDO::PARAM_INT))
+			->where($query->expr()->eq('session_id', $query->createNamedParameter($sessionId)));
+		QueryHelper::executeStatement($query);
+	}
+
+	/**
 	 * Drop a single session, for a client that said it was leaving rather than
 	 * one that stopped polling.
 	 */

--- a/lib/Command/FlushChanges.php
+++ b/lib/Command/FlushChanges.php
@@ -71,16 +71,21 @@ class FlushChanges extends Base {
 			if (!$input->getOption('inactive-pages') ||
 			   !$this->sessionManager->isDocumentActive($documentId)) {
 				try {
+					// A document that is still being edited is written out
+					// without its editing session being ended; see
+					// SaveHandler::flushChanges().
 					$this->saveHandler->flushChanges($documentId);
 				} catch (\Exception $e) {
 					$this->logger->error(
-						'Error while applying changes for document ' . $documentId, 
+						'Error while applying changes for document ' . $documentId,
 						['exception' => $e, 'app' => 'documentserver_community']
 					);
-					return 0;
+					// the exit codes were the wrong way round, which makes the
+					// command unusable from cron or a && chain
+					return 1;
 				}
 			}
 		}
-		return 1;
+		return 0;
 	}
 }

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -59,9 +59,18 @@ use Psr\Log\LoggerInterface;
 
 class DocumentController extends Controller {
 	/**
-	 * How long the close beacon waits before it acts on what the page told it,
-	 * in seconds. Long enough for a save that was already on its way when the
-	 * editor was torn down to be stored first.
+	 * How long the close beacon waits before acting, in seconds: long enough
+	 * for a save the editor got out on its way down to be stored first, rather
+	 * than ending the session under it and turning its last changes into a
+	 * rejected command.
+	 *
+	 * It cannot also be used to check whether the page really went away. The
+	 * poll that session left behind keeps running server-side for up to
+	 * Channel::TIMEOUT seconds and marks the session as seen while it does, so
+	 * a session that is being polled by nobody looks exactly like a live one.
+	 * What the message says is trusted instead, and it is the sender that makes
+	 * that safe: js/close-beacon-host.js only sends it once the editor's frame
+	 * has left the document.
 	 */
 	private const CLOSE_GRACE = 3;
 
@@ -162,21 +171,24 @@ class DocumentController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	public function sessionClosed(string $sid): Response {
-		if (!$this->sessionManager->getSession($sid)) {
+		$session = $this->sessionManager->getSession($sid);
+		if (!$session) {
 			return new DataResponse('ok');
 		}
 
 		// Nothing is waiting on this response - the page that sent it is gone -
-		// so hold it long enough for a save the editor managed to get out on
-		// its way down to arrive first, rather than ending the session under it
-		// and turning its last changes into a rejected command.
+		// so hold it for the grace period first.
 		ignore_user_abort(true);
 		sleep(self::CLOSE_GRACE);
 
 		$session = $this->sessionManager->getSession($sid);
-		if ($session) {
-			$this->sessionCloser->sessionLeft($session);
+		if (!$session) {
+			// gone already: the session expired, or a second beacon for the
+			// same editor got here first
+			return new DataResponse('ok');
 		}
+
+		$this->sessionCloser->sessionLeft($session);
 
 		return new DataResponse('ok');
 	}

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -25,6 +25,7 @@ namespace OCA\DocumentServer\Controller;
 
 use OCA\DocumentServer\Channel\Channel;
 use OCA\DocumentServer\Channel\ChannelFactory;
+use OCA\DocumentServer\Channel\SessionCloser;
 use OCA\DocumentServer\Channel\SessionManager;
 use OCA\DocumentServer\Document\DocumentStore;
 use OCA\DocumentServer\EngineIOResponse;
@@ -34,6 +35,7 @@ use OCA\DocumentServer\OnlyOffice\URLDecoder;
 use OCA\DocumentServer\OnlyOffice\WebVersion;
 use OCA\DocumentServer\XHRCommand\AuthCommand;
 use OCA\DocumentServer\XHRCommand\ChatMessage;
+use OCA\DocumentServer\XHRCommand\CloseSession;
 use OCA\DocumentServer\XHRCommand\CommandDispatcher;
 use OCA\DocumentServer\XHRCommand\CursorCommand;
 use OCA\DocumentServer\XHRCommand\GetLock;
@@ -56,6 +58,13 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 class DocumentController extends Controller {
+	/**
+	 * How long the close beacon waits before it acts on what the page told it,
+	 * in seconds. Long enough for a save that was already on its way when the
+	 * editor was torn down to be stored first.
+	 */
+	private const CLOSE_GRACE = 3;
+
 	public const COMMAND_HANDLERS = [
 		AuthCommand::class,
 		IsSaveLock::class,
@@ -66,6 +75,7 @@ class DocumentController extends Controller {
 		OpenDocument::class,
 		ChatMessage::class,
 		GetMessages::class,
+		CloseSession::class,
 	];
 
 	public const IDLE_HANDLERS = [
@@ -81,6 +91,7 @@ class DocumentController extends Controller {
 	private $webVersion;
 	private $ipcFactory;
 	private $sessionManager;
+	private SessionCloser $sessionCloser;
 	private LoggerInterface $logger;
 	private ContainerInterface $container;
 
@@ -94,6 +105,7 @@ class DocumentController extends Controller {
 		WebVersion $webVersion,
 		IIPCFactory $ipcFactory,
 		SessionManager $sessionManager,
+		SessionCloser $sessionCloser,
 		LoggerInterface $logger,
 		ContainerInterface $container
 	) {
@@ -106,6 +118,7 @@ class DocumentController extends Controller {
 		$this->webVersion = $webVersion;
 		$this->ipcFactory = $ipcFactory;
 		$this->sessionManager = $sessionManager;
+		$this->sessionCloser = $sessionCloser;
 		$this->logger = $logger;
 		$this->container = $container;
 	}
@@ -136,6 +149,36 @@ class DocumentController extends Controller {
 				'plugins' => false,
 			],
 		]];
+	}
+
+	/**
+	 * The editor page reporting that it is going away; see js/close-beacon.js.
+	 *
+	 * Ends that session and, if it was the last one in the document, writes the
+	 * document out - the work the browser closing a WebSocket would do on a
+	 * document server that had one.
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[PublicPage]
+	public function sessionClosed(string $sid): Response {
+		if (!$this->sessionManager->getSession($sid)) {
+			return new DataResponse('ok');
+		}
+
+		// Nothing is waiting on this response - the page that sent it is gone -
+		// so hold it long enough for a save the editor managed to get out on
+		// its way down to arrive first, rather than ending the session under it
+		// and turning its last changes into a rejected command.
+		ignore_user_abort(true);
+		sleep(self::CLOSE_GRACE);
+
+		$session = $this->sessionManager->getSession($sid);
+		if ($session) {
+			$this->sessionCloser->sessionLeft($session);
+		}
+
+		return new DataResponse('ok');
 	}
 
 	#[NoAdminRequired]

--- a/lib/Controller/StaticController.php
+++ b/lib/Controller/StaticController.php
@@ -37,12 +37,14 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\Files\IMimeTypeDetector;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 
 class StaticController extends Controller {
 	private $mimeTypeHelper;
 	private $nonceManager;
 	private $setupCheck;
 	private $sessionManager;
+	private $urlGenerator;
 
 	public function __construct(
 		$appName,
@@ -50,7 +52,8 @@ class StaticController extends Controller {
 		IMimeTypeDetector $mimeTypeHelper,
 		ContentSecurityPolicyNonceManager $nonceManager,
 		SetupCheck $setupCheck,
-		SessionManager $sessionManager
+		SessionManager $sessionManager,
+		IURLGenerator $urlGenerator
 	) {
 		parent::__construct($appName, $request);
 
@@ -58,6 +61,7 @@ class StaticController extends Controller {
 		$this->nonceManager = $nonceManager;
 		$this->setupCheck = $setupCheck;
 		$this->sessionManager = $sessionManager;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	#[NoCSRFRequired]
@@ -124,6 +128,13 @@ class StaticController extends Controller {
 				$content = str_replace('__HINT__', addcslashes($hint, "'"), $rawContent);
 				return $this->createFileResponseWithContent($localPath, $content, false);
 			}
+
+			// the page that embeds the editor is the one that can still say
+			// goodbye when the editor's own frame is being removed
+			return $this->createFileResponseWithContent(
+				$localPath,
+				file_get_contents($localPath) . "\n" . $this->closeBeacon('close-beacon-host.js')
+			);
 		}
 
 		return $this->createFileResponse($localPath);
@@ -140,6 +151,8 @@ class StaticController extends Controller {
 	private function createFileResponseWithContent(string $path, string $content, $cache = true) {
 		$isHTML = pathinfo($path, PATHINFO_EXTENSION) === 'html';
 		if ($isHTML) {
+			// before the nonce is applied, so the injected script gets one too
+			$content = $this->addCloseBeacon($path, $content);
 			$content = $this->addScriptNonce($content, $this->nonceManager->getNonce());
 			$content = $this->makeStyleSheetsBlocking($content);
 		}
@@ -170,6 +183,51 @@ class StaticController extends Controller {
 		$response->setContentSecurityPolicy($csp);
 
 		return $response;
+	}
+
+	/**
+	 * Have the editor page tell us when it goes away.
+	 *
+	 * A document server that holds a WebSocket learns of a closed editor from
+	 * the socket closing. Ours is polled over HTTP, so a closed tab - or
+	 * DocsAPI's destroyEditor(), which takes the iframe out of the DOM without
+	 * the code inside it getting a word in - leaves a poll that simply never
+	 * comes back, with nothing running to notice. The document then waited for
+	 * the Cleanup background job to be scheduled before it was written at all
+	 * (#100).
+	 *
+	 * Injected rather than shipped as a file reference so it is covered by the
+	 * nonce added below, and only into the editor entry points: the same tree
+	 * serves help pages and loaders that never open a socket.
+	 */
+	private function addCloseBeacon(string $path, string $content): string {
+		if (!preg_match('#/apps/\w+editor/main/index[\w.]*\.html$#', str_replace('\\', '/', $path))) {
+			return $content;
+		}
+
+		$injected = '<script>' . $this->closeBeacon('close-beacon.js') . '</script>';
+
+		$head = stripos($content, '</head>');
+		if ($head === false) {
+			return $content . $injected;
+		}
+
+		return substr($content, 0, $head) . $injected . substr($content, $head);
+	}
+
+	/**
+	 * One of the goodbye scripts, with the address to send it to.
+	 */
+	private function closeBeacon(string $file): string {
+		$script = @file_get_contents(__DIR__ . '/../../js/' . $file);
+		if ($script === false) {
+			return '';
+		}
+
+		$closeUrl = $this->urlGenerator->linkToRoute('documentserver_community.Document.sessionClosed');
+
+		return 'window.__documentServerCloseUrl = window.__documentServerCloseUrl || '
+			. json_encode($closeUrl) . ";\n" . $script;
 	}
 
 	private function addScriptNonce(string $content, string $nonce): string {

--- a/lib/Document/DocumentStore.php
+++ b/lib/Document/DocumentStore.php
@@ -37,9 +37,18 @@ use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Lock\LockedException;
 
 class DocumentStore {
 	private const CHAT_FILE = 'chat.json';
+	private const SNAPSHOT_FILE = 'snapshot';
+
+	/**
+	 * How many times writing the assembled document back to its file is
+	 * retried when Nextcloud's file locking says something else is busy with
+	 * it.
+	 */
+	private const WRITE_ATTEMPTS = 5;
 	private const CHAT_HISTORY_LIMIT = 100;
 
 	private $appData;
@@ -173,10 +182,35 @@ class DocumentStore {
 			$oldUser = $this->userSession->getUser();
 			$this->userSession->setUser($ownerObject);
 
-			$sourceFile->putContent(stream_get_contents($savedContent));
+			$this->writeSourceFile($sourceFile, stream_get_contents($savedContent));
 
 			$this->userSession->setUser($oldUser);
 		});
+	}
+
+	/**
+	 * Write the assembled document back over the file it came from.
+	 *
+	 * Nextcloud's file locking makes this fail while anything else is holding
+	 * the file - a preview being generated, a sync client downloading it - and
+	 * that is not unlikely at the moment somebody closes an editor and lands
+	 * back in the file list, which is where the previews come from. The
+	 * document has already been assembled by then, so waiting out a lock that
+	 * is measured in milliseconds is much cheaper than leaving the file
+	 * unwritten until a background job comes round.
+	 */
+	private function writeSourceFile(File $sourceFile, string $content): void {
+		for ($attempt = 1;; $attempt++) {
+			try {
+				$sourceFile->putContent($content);
+				return;
+			} catch (LockedException $e) {
+				if ($attempt >= self::WRITE_ATTEMPTS) {
+					throw $e;
+				}
+				usleep($attempt * 500 * 1000);
+			}
+		}
 	}
 
 	/**
@@ -287,6 +321,47 @@ class DocumentStore {
 			$messages = array_slice($messages, -self::CHAT_HISTORY_LIMIT);
 		}
 		$docFolder->newFile(self::CHAT_FILE)->putContent(json_encode($messages));
+	}
+
+	/**
+	 * When the document was last written out to its file, and the change index
+	 * it stood at then.
+	 *
+	 * This is what lets a document be written out repeatedly while it is being
+	 * edited without paying for a converter run every time: a document nobody
+	 * has typed into since the last write is already on disk, and one that has
+	 * just been written is not due again until the interval has passed.
+	 *
+	 * The index is -1 for a document that has never been written out, so that
+	 * index 0 - open, one change made - is not mistaken for it. It lives in the
+	 * document's own folder, so it is disposed of with the document.
+	 *
+	 * @return array{index: int, time: int}
+	 */
+	public function getSnapshotState(int $documentId): array {
+		$docFolder = $this->getDocumentFolder($documentId);
+		try {
+			$state = json_decode($docFolder->getFile(self::SNAPSHOT_FILE)->getContent(), true);
+		} catch (NotFoundException $e) {
+			$state = null;
+		}
+
+		if (!is_array($state)) {
+			$state = [];
+		}
+
+		return [
+			'index' => isset($state['index']) ? (int)$state['index'] : -1,
+			'time' => isset($state['time']) ? (int)$state['time'] : 0,
+		];
+	}
+
+	public function setSnapshotState(int $documentId, int $changeIndex, int $time): void {
+		$docFolder = $this->getDocumentFolder($documentId);
+		$docFolder->newFile(self::SNAPSHOT_FILE)->putContent(json_encode([
+			'index' => $changeIndex,
+			'time' => $time,
+		]));
 	}
 
 	public function stashDocumentUrl(int $documentId, string $url) {

--- a/lib/Document/SaveHandler.php
+++ b/lib/Document/SaveHandler.php
@@ -25,44 +25,170 @@ namespace OCA\DocumentServer\Document;
 
 use OCA\DocumentServer\Channel\SessionManager;
 use OCA\DocumentServer\DocumentConverter;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
 
 class SaveHandler {
+	/**
+	 * How long flushing waits for a write that is already in progress, in
+	 * seconds. The lock is only ever held for as long as the converter takes,
+	 * and the caller that waits is usually the last editor leaving - the one
+	 * moment where giving up means the document waits for a background job.
+	 */
+	private const LOCK_WAIT = 15;
+
 	private $documentStore;
 	private $changeStore;
 	private $documentConverter;
 	private $lockingProvider;
 	private $sessionManager;
+	private $timeFactory;
 
 	public function __construct(
 		DocumentStore $documentStore,
 		ChangeStore $changeStore,
 		DocumentConverter $documentConverter,
 		ILockingProvider $lockingProvider,
-		SessionManager $sessionManager
+		SessionManager $sessionManager,
+		ITimeFactory $timeFactory
 	) {
 		$this->documentStore = $documentStore;
 		$this->changeStore = $changeStore;
 		$this->documentConverter = $documentConverter;
 		$this->lockingProvider = $lockingProvider;
 		$this->sessionManager = $sessionManager;
+		$this->timeFactory = $timeFactory;
 	}
 
-	public function flushChanges(int $documentId) {
-		$this->lockingProvider->acquireLock('documentserver_' . $documentId, ILockingProvider::LOCK_EXCLUSIVE);
+	/**
+	 * Write the document out as it stands, leaving the editing session running.
+	 *
+	 * Not the same job as flushChanges(), which is for a session that is
+	 * ending. saveChanges() replays the change list against the document's
+	 * Editor.bin without rebasing it, so consuming the changes mid-session
+	 * strands the document twice over: a session opened afterwards replays an
+	 * empty list against the untouched baseline and shows the pre-save
+	 * document, and the eventual flush writes the file from a change list that
+	 * no longer holds the earlier edits, losing them.
+	 *
+	 * So a snapshot reads the changes and leaves them alone. The eventual flush
+	 * replays the same list against the same baseline and produces the same
+	 * document, which is what makes writing one out early free of consequence.
+	 *
+	 * @return bool whether the document was written
+	 */
+	public function saveSnapshot(int $documentId): bool {
+		try {
+			$this->lockingProvider->acquireLock('documentserver_' . $documentId, ILockingProvider::LOCK_EXCLUSIVE);
+		} catch (LockedException $e) {
+			// somebody else is already writing this document out; theirs
+			// covers everything ours would have
+			return false;
+		}
 
 		try {
+			return $this->writeDocument($documentId);
+		} finally {
+			$this->lockingProvider->releaseLock('documentserver_' . $documentId, ILockingProvider::LOCK_EXCLUSIVE);
+		}
+	}
+
+	/**
+	 * Take the document lock, waiting for a write that is already running.
+	 *
+	 * Nextcloud's locking does not block, so without this a write that is
+	 * already assembling the document turns the flush behind it into a failure
+	 * rather than a wait.
+	 *
+	 * @throws LockedException if the document is still being written after
+	 *                         LOCK_WAIT seconds
+	 */
+	private function acquireLockWaiting(int $documentId): void {
+		$deadline = $this->timeFactory->getTime() + self::LOCK_WAIT;
+
+		while (true) {
+			try {
+				$this->lockingProvider->acquireLock('documentserver_' . $documentId, ILockingProvider::LOCK_EXCLUSIVE);
+				return;
+			} catch (LockedException $e) {
+				if ($this->timeFactory->getTime() >= $deadline) {
+					throw $e;
+				}
+				usleep(500 * 1000);
+			}
+		}
+	}
+
+	/**
+	 * Write the assembled document to its file. Caller holds the document lock.
+	 *
+	 * The time is recorded before the converter runs as well as after it, so
+	 * that a document which fails to assemble backs off instead of being
+	 * retried by every writer that comes along.
+	 */
+	private function writeDocument(int $documentId): bool {
+		$changeIndex = $this->changeStore->getMaxChangeIndexForDocument($documentId);
+		$state = $this->documentStore->getSnapshotState($documentId);
+		$now = $this->timeFactory->getTime();
+
+		if ($changeIndex === $state['index']) {
+			// nothing typed since the last write: the file is already current
+			$this->documentStore->setSnapshotState($documentId, $changeIndex, $now);
+			return false;
+		}
+
+		$this->documentStore->setSnapshotState($documentId, $state['index'], $now);
+
+		$changes = $this->changeStore->getChangesForDocument($documentId);
+		if (count($changes)) {
+			$this->documentStore->saveChanges($documentId, $changes);
+		}
+
+		$this->documentStore->setSnapshotState($documentId, $changeIndex, $now);
+
+		return true;
+	}
+
+	/**
+	 * Write the document out and end its editing session: the change list is
+	 * consumed and the document folder disposed of.
+	 *
+	 * Only safe once the last participant has left, because the change list is
+	 * the only record of everything typed - Editor.bin stays at the version the
+	 * document was opened at. So the state is checked again under the lock, and
+	 * again after the converter has run, and a document that turned out to
+	 * still be open is only written, never emptied.
+	 */
+	public function flushChanges(int $documentId) {
+		$this->acquireLockWaiting($documentId);
+
+		try {
+			if ($this->sessionManager->isDocumentActive($documentId)) {
+				$this->writeDocument($documentId);
+				return;
+			}
+
+			$changeIndex = $this->changeStore->getMaxChangeIndexForDocument($documentId);
 			$changes = $this->changeStore->getChangesAndMarkProcessingForDocument($documentId);
 
 			if (count($changes)) {
 				$this->documentStore->saveChanges($documentId, $changes);
-
-				$this->changeStore->deleteProcessedChanges($documentId);
 			}
 
-			if (!$this->sessionManager->isDocumentActive($documentId)) {
-				$this->documentStore->closeDocument($documentId);
+			if ($this->sessionManager->isDocumentActive($documentId)) {
+				// Somebody opened the document while it was being assembled.
+				// Their session is editing against the change list we just
+				// replayed, so leave it, and the baseline it applies to, in
+				// place: the file is written, and the next flush writes the
+				// same document again.
+				$this->changeStore->unmarkProcessing($documentId);
+				$this->documentStore->setSnapshotState($documentId, $changeIndex, $this->timeFactory->getTime());
+				return;
 			}
+
+			$this->changeStore->deleteProcessedChanges($documentId);
+			$this->documentStore->closeDocument($documentId);
 		} catch (\Exception $e) {
 			$this->changeStore->unmarkProcessing($documentId);
 			throw $e;

--- a/lib/Document/SaveHandler.php
+++ b/lib/Document/SaveHandler.php
@@ -26,10 +26,19 @@ namespace OCA\DocumentServer\Document;
 use OCA\DocumentServer\Channel\SessionManager;
 use OCA\DocumentServer\DocumentConverter;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 
 class SaveHandler {
+	/**
+	 * How long a document being edited may go without being written to its
+	 * file, in seconds. Overridable with
+	 * `occ config:app:set documentserver_community autosave_interval --value=...`,
+	 * 0 turns the periodic write off.
+	 */
+	public const DEFAULT_AUTOSAVE_INTERVAL = 60;
+
 	/**
 	 * How long flushing waits for a write that is already in progress, in
 	 * seconds. The lock is only ever held for as long as the converter takes,
@@ -43,6 +52,7 @@ class SaveHandler {
 	private $documentConverter;
 	private $lockingProvider;
 	private $sessionManager;
+	private $config;
 	private $timeFactory;
 
 	public function __construct(
@@ -51,6 +61,7 @@ class SaveHandler {
 		DocumentConverter $documentConverter,
 		ILockingProvider $lockingProvider,
 		SessionManager $sessionManager,
+		IConfig $config,
 		ITimeFactory $timeFactory
 	) {
 		$this->documentStore = $documentStore;
@@ -58,7 +69,37 @@ class SaveHandler {
 		$this->documentConverter = $documentConverter;
 		$this->lockingProvider = $lockingProvider;
 		$this->sessionManager = $sessionManager;
+		$this->config = $config;
 		$this->timeFactory = $timeFactory;
+	}
+
+	/**
+	 * Write the document out if it has gone longer than the autosave interval
+	 * without being written.
+	 *
+	 * Called from the editing path itself, which is what makes it independent
+	 * of the admin's cron: a document that is being typed into reaches its file
+	 * on its own, whether or not the background job ever runs.
+	 *
+	 * @return bool whether the document was written
+	 */
+	public function saveSnapshotIfDue(int $documentId): bool {
+		$interval = (int)$this->config->getAppValue(
+			'documentserver_community',
+			'autosave_interval',
+			(string)self::DEFAULT_AUTOSAVE_INTERVAL
+		);
+
+		if ($interval <= 0) {
+			return false;
+		}
+
+		$state = $this->documentStore->getSnapshotState($documentId);
+		if (($this->timeFactory->getTime() - $state['time']) < $interval) {
+			return false;
+		}
+
+		return $this->saveSnapshot($documentId);
 	}
 
 	/**
@@ -124,8 +165,8 @@ class SaveHandler {
 	 * Write the assembled document to its file. Caller holds the document lock.
 	 *
 	 * The time is recorded before the converter runs as well as after it, so
-	 * that a document which fails to assemble backs off instead of being
-	 * retried by every writer that comes along.
+	 * that a document which fails to assemble backs off to the autosave
+	 * interval instead of being retried on every save.
 	 */
 	private function writeDocument(int $documentId): bool {
 		$changeIndex = $this->changeStore->getMaxChangeIndexForDocument($documentId);

--- a/lib/XHRCommand/CloseSession.php
+++ b/lib/XHRCommand/CloseSession.php
@@ -28,14 +28,20 @@ use OCA\DocumentServer\Channel\SessionCloser;
 use OCA\DocumentServer\IPC\IIPCChannel;
 
 /**
- * sdkjs stepping out of the document, from DocsCoApi.disconnect(): the editor
- * dropping to view mode, a document reopened under a new url, rights taken
- * away. The session is done sending changes either way, so it is treated as a
- * departure - see SessionCloser.
+ * sdkjs stepping out of co-authoring, from DocsCoApi.disconnect().
  *
- * The editor being closed does not come through here. DocsAPI's destroyEditor()
- * takes the iframe out of the DOM, which gives the code inside it no chance to
- * say anything; that path is covered by the unload beacon
+ * This is not the editor being closed, and must not be treated as one. sdkjs
+ * sends it whenever it drops the editor to view mode while the page stays
+ * open: a licence verdict on the number of users in the document - which is
+ * evaluated as soon as there is a second participant - rights taken away,
+ * disconnectEveryone, a critical error, a document reopened under a new url.
+ * Ending the session here and writing the document out took the document
+ * folder away from a page that was still editing.
+ *
+ * So it only stops the session being a participant, and a client that turns
+ * out to still be polling revives itself. Closing the editor - destroyEditor()
+ * taking the iframe out of the DOM - and closing the tab say nothing at all
+ * through this channel; they are covered by the unload beacon
  * (js/close-beacon.js).
  */
 class CloseSession implements ICommandHandler {
@@ -50,6 +56,6 @@ class CloseSession implements ICommandHandler {
 	}
 
 	public function handle(array $command, Session $session, IIPCChannel $sessionChannel, IIPCChannel $documentChannel, CommandDispatcher $commandDispatcher): void {
-		$this->sessionCloser->sessionLeft($session);
+		$this->sessionCloser->sessionStoppedCoAuthoring($session);
 	}
 }

--- a/lib/XHRCommand/CloseSession.php
+++ b/lib/XHRCommand/CloseSession.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2026 Fabrice Meyer <meyer.fabrice@gmx.fr>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\DocumentServer\XHRCommand;
+
+use OCA\DocumentServer\Channel\Session;
+use OCA\DocumentServer\Channel\SessionCloser;
+use OCA\DocumentServer\IPC\IIPCChannel;
+
+/**
+ * sdkjs stepping out of the document, from DocsCoApi.disconnect(): the editor
+ * dropping to view mode, a document reopened under a new url, rights taken
+ * away. The session is done sending changes either way, so it is treated as a
+ * departure - see SessionCloser.
+ *
+ * The editor being closed does not come through here. DocsAPI's destroyEditor()
+ * takes the iframe out of the DOM, which gives the code inside it no chance to
+ * say anything; that path is covered by the unload beacon
+ * (js/close-beacon.js).
+ */
+class CloseSession implements ICommandHandler {
+	private $sessionCloser;
+
+	public function __construct(SessionCloser $sessionCloser) {
+		$this->sessionCloser = $sessionCloser;
+	}
+
+	public function getType(): string {
+		return 'close';
+	}
+
+	public function handle(array $command, Session $session, IIPCChannel $sessionChannel, IIPCChannel $documentChannel, CommandDispatcher $commandDispatcher): void {
+		$this->sessionCloser->sessionLeft($session);
+	}
+}

--- a/lib/XHRCommand/SaveChangesCommand.php
+++ b/lib/XHRCommand/SaveChangesCommand.php
@@ -28,18 +28,30 @@ use OCA\DocumentServer\Document\Change;
 use OCA\DocumentServer\Document\ChangeStore;
 use OCA\DocumentServer\Document\Lock;
 use OCA\DocumentServer\Document\LockStore;
+use OCA\DocumentServer\Document\SaveHandler;
 use OCA\DocumentServer\IPC\IIPCChannel;
 use OCP\AppFramework\Utility\ITimeFactory;
+use Psr\Log\LoggerInterface;
 
 class SaveChangesCommand implements ICommandHandler {
 	private $changeStore;
 	private $lockStore;
 	private $timeFactory;
+	private $saveHandler;
+	private $logger;
 
-	public function __construct(ChangeStore $changeStore, LockStore $lockStore, ITimeFactory $timeFactory) {
+	public function __construct(
+		ChangeStore $changeStore,
+		LockStore $lockStore,
+		ITimeFactory $timeFactory,
+		SaveHandler $saveHandler,
+		LoggerInterface $logger
+	) {
 		$this->changeStore = $changeStore;
 		$this->lockStore = $lockStore;
 		$this->timeFactory = $timeFactory;
+		$this->saveHandler = $saveHandler;
+		$this->logger = $logger;
 	}
 
 	public function getType(): string {
@@ -128,5 +140,27 @@ class SaveChangesCommand implements ICommandHandler {
 
 		$now = time() * 1000;
 		$sessionChannel->pushMessage('{"type":"unSaveLock","index":' . $changeIndex . ',"time":' . $now . '}');
+
+		// Write the document out if it has been long enough since the last
+		// time. The editor's "all changes are saved" only ever meant that the
+		// changes reached this server: nothing was written to the file until
+		// the last participant had left and the background job had run, so a
+		// browser closed at the wrong moment, or a server that went down, lost
+		// the whole session's work (#100). Doing it from here rather than only
+		// from the job is what makes it independent of the admin's cron.
+		//
+		// After the reply, not before it: assembling the document takes a
+		// second or two, and the client waits for its unSaveLock before it
+		// sends the next batch of changes.
+		try {
+			$this->saveHandler->saveSnapshotIfDue($session->getDocumentId());
+		} catch (\Throwable $e) {
+			// the changes are stored, so this is a write to retry later, not a
+			// failed save
+			$this->logger->warning('documentserver could not write document {doc} out while it is being edited', [
+				'doc' => $session->getDocumentId(),
+				'exception' => $e,
+			]);
+		}
 	}
 }


### PR DESCRIPTION
Fixes the long-standing #100: "Edits and changes made in OnlyOffice are not synced
  into Nextcloud".

  ## The problem

  The file was written in exactly one place — the `Cleanup` background job — and only
  for a document whose sessions had all expired. Everything typed lived in
  `oc_documentserver_changes` until cron came round *after the last participant left*.
  On an instance whose cron is slow, misconfigured, or set to AJAX, that was never, and
  the editor's "all changes are saved" meant the changes had reached this server, not
  that they had reached the file.

  Two sharper bugs sat behind that:

  - `flushChanges()` applied the changes, **deleted them**, and only then asked whether
    anybody was still editing. The change list is the whole record of what was typed —
    `Editor.bin` stays at the version the document was opened at, and every write
    replays the list against it — so consuming it mid-session leaves the file's
    correctness resting on sdkjs noticing the server's index went backwards and
    resending its entire history. It does, which is why this is hard to catch, but it is
    an undocumented dependency on client behaviour rather than something the server
    guarantees. Measured on master: `occ documentserver:flush` with a session still open
    takes the change list from 100 rows to 0.
  - The `closeDocument()` that follows would delete the document folder under a session
    that arrived after the Cleanup job's out-of-lock activity check.

  ## What this does

  **1. Separates writing a document from ending its session** (`SaveHandler`).
  `saveSnapshot()` writes the file and leaves the change list and the baseline alone, so
  the eventual flush replays the same list against the same document and produces the
  same result. `flushChanges()` — consume and dispose — now decides under the lock and
  re-checks after the converter has run; a document that turned out to still be open is
  only written, never emptied. Also in here because it is the same path: the flush waits
  for a write already in progress instead of failing on the lock, writing the file
  retries while Nextcloud's file locking says something else is holding it (a preview, a
  sync client), and `documentserver:flush` returns 0 on success rather than 1.

  **2. Writes the document out while it is being edited.** A save assembles the document
  if it has been longer than `autosave_interval` (app config, default 60 s, `0` disables)
  since the last write. Driven from the editing path rather than only from the job, so it
  does not depend on the admin's cron. One assembly per interval per document being
  edited, however much is typed in between, and none at all while nobody is typing — a
  `snapshot` file in the document folder holds `{index, time}`. The write happens after
  the client has been answered, because it takes a second or two and the client waits for
  its `unSaveLock` before sending the next batch. The Cleanup job now snapshots live
  documents instead of skipping them.

  **3. Saves the document when the last editor leaves**, instead of waiting for the job.
  A real document server learns of a closed editor from a closed WebSocket; this one is
  polled over HTTP, so the pending poll is simply dropped and nothing runs to notice.

  Two paths get there, because sdkjs only covers one:

  - sdkjs sends a `close` command from `DocsCoApi.disconnect()` (dropped to view mode,
    rights taken away) — that command was being ignored and is now handled.
  - Closing the editor is *not* that. `DocsAPI.DocEditor.destroyEditor()`, which the
    connector's close button calls, takes the iframe out of the DOM and the code inside it
    never gets a word in; closing the tab says nothing either, and sdkjs sets socket.io's
    `closeOnBeforeunload: false`, so there is no transport-level close packet. Those are
    covered by a beacon: the editor frame publishes the session id it picks out of the
cumentserver_community), tracking set up.